### PR TITLE
Add LFI compartmentalization evaluation

### DIFF
--- a/evaluations/lfi.md
+++ b/evaluations/lfi.md
@@ -1,0 +1,158 @@
+# Compartmentalization Evaluation Matrix — LFI
+
+**System:** LFI (Lightweight Fault Isolation) — an SFI scheme for ARM64
+**Paper:** Z. Yedidia. *Lightweight Fault Isolation: Practical, Efficient, and Secure Software Sandboxing.* ASPLOS 2024. DOI 10.1145/3620665.3640408.
+**Source file:** `papers/lfi.pdf`
+**Matrix version:** v0.1
+**Evaluated:** 2026-06-08
+
+> ✅ / ❌ for checkboxes; categorical scales and short text otherwise.
+>
+> **Sourcing legend:** **(§N)** = stated in paper · **[repo]** = from git repo/site · **_Inferred:_** = evaluator assessment, not a paper claim · **⚠️ Unclear** = not found, needs research.
+>
+> _Compartment = a **sandbox**: an aligned 4 GiB region in a shared address space, into which untrusted code is loaded after a static machine-code verifier confirms its loads/stores/jumps are guarded. Pure software fault isolation (SFI), no hardware isolation primitive._
+
+---
+
+## Security
+
+| **Dimension** | **Metric** | **Value / Notes** |
+|----------------|------------|-------------------|
+| **Isolation Model** | | |
+| Primary use case | Untrusted component isolation / Secret protection / Fault isolation / Other | **Untrusted component isolation** — sandboxing untrusted code with low latency for cloud/serverless; a lighter "stores+jumps only" mode targets **fault isolation / software compartmentalization** (read-only cross-sandbox) (Abstract, §1, §6.1). |
+| Subject selection | Code-centric / Data-centric / Hybrid | **Code-centric** — sandboxes code (an untrusted program/module) (§3). |
+| Code-centric granularity | Function / Library / Thread / Process / VM / N/A | **Process-like sandbox** — a 4 GiB isolation domain holding a program, in a shared address space (§3, Fig. 1). |
+| Data-centric granularity | Object / Region / Page / Allocation / File / N/A | **N/A** — isolation is per-4 GiB-region. |
+| **Isolation Approach** | | |
+| Hardware primitive(s) | MPK/PKU / MTE / CHERI / TEEs / Other / None | **None** — classic SFI via software guard instructions; uses only **standard page protections (W⊕X), set once at init** (no per-switch hardware involvement) (§3). |
+| Software technique(s) | SFI / Boundary wrappers/marshalling / Memory-safe language / Language runtime / Other / None | **SFI** — guard instructions on loads/stores/jumps (exploiting ARM64 addressing modes for ~0–1 cycle guards) + a **static machine-code verifier** (§3, §4, §5.2). |
+| Isolation abstraction | Process / Thread / Intra-Address Space Domain / VM / Container / Other | **Intra-Address Space Domain** — tens of thousands of sandboxes in one address space (§1, §3). |
+| Requires runtime software support | ✅ / ❌ (describe) | **✅** — a runtime (manages sandboxes, mediated runtime calls, scheduling, fast IPC), the static verifier, and the LFI assembly transformer (§5). |
+| **Properties Enforced** | | |
+| Security properties provided | [Describe] | **Full software isolation of loads, stores, and jumps** — a sandbox cannot read/write/jump outside its 4 GiB region (the static verifier guarantees the reserved-register + guard invariants); plus a "no-loads" mode (stores+jumps only) that permits read-only cross-sandbox access for compartmentalization; Spectre-breakout safety by construction (§3, §5.2, §6.1, §7.1). |
+| **Resilience** | | |
+| Compartment crashes isolated | ✅ / ❌ | _Inferred:_ **✅** — out-of-bounds accesses hit unmapped guard regions and **trap** (page fault → signal to the runtime); the runtime mediates and schedules sandboxes (§3, §5.3). Not framed as an explicit recovery experiment. |
+| **Interface Safety** | | |
+| Provides means to facilitate boundary checking/validation | ✅ / ❌ / Partial | **✅** — the runtime mediates all runtime calls and **checks arguments** (e.g., can disallow access to certain directories); the static verifier rejects any binary using unsafe instructions/addressing (§5.2, §5.3). |
+| **Trust & Threats** | | |
+| TCB includes | Compiler / OS / Firmware / CPU / Other (list) | **Static verifier** (+ its disassembler/ELF-reader/instruction-def dependencies), the **runtime**, and the **OS/CPU**. The **compiler and the LFI assembly transformer are NOT trusted** — the verifier checks the final machine code (§5.1, §5.2). |
+| TCB approximate size | Small / Medium / Large / Very Large or [LOC] | **Small** — verifier **core = 300 LOC Rust** (excludes LLVM's ~2M LOC from the TCB), though external deps (Binary Ninja disassembler, ELF reader, instruction defs) are "larger than we'd like." The LFI transformer (~1,500 LOC) is outside the TCB (§5.1, §5.2). |
+| Side-channel resistance | Cache / Timing / Speculative / Other / None (mitigations) | **✅ (partial, Spectre)** — **sandbox-breakout mitigated by construction** (LFI relies on no fine-grained CFI; all jumps are data-flow-guarded, so speculative jumps stay in-sandbox). Cross-sandbox / host **poisoning** needs ARM's **CSV2_2** extension (Cortex-X2+, not universal) (§7.1). Stronger than most software systems in this set. |
+| **Validation** | | |
+| Formal validation available | Yes (specify) / No | **No** formal proof — but the verifier's disassembler/instruction definitions are auto-generated from **Arm's Machine Readable Specification (MRS)**, a formal ISA spec (§5.2). |
+| Experimental validation available | Yes (specify) / No | **Yes** — SPEC CPU 2017 (14 benchmarks), comparison vs Wasm engines (Wasmtime/Wasm2c/WAMR), vs hardware virtualization (KVM) + gVisor, context-switch microbenchmarks, and a Spectre analysis. Hosts: Apple M1 (Asahi Linux) + GCP T2A (§6). Artifact (MPL 2.0). |
+
+---
+
+## Runtime Efficiency
+
+| **Dimension** | **Metric** | **Value / Notes** |
+|----------------|------------|-------------------|
+| General runtime overhead | SPEC 2017 (platform/native) | **SPEC 2017**: geomean **6.4% (Apple M1) / 7.3% (GCP T2A)** for full isolation (O2); **~1%** for the stores+jumps-only ("no loads") mode; worst single benchmark 17% (leela). vs Wasm: roughly **half** Wasm's overhead (WAMR 18–22%, Wasm2c-pinned 16%, Wasmtime 47–67%) (§6.1–6.2, Tables 4). |
+| Domain switch cost | lmbench lat_ctx (platform/native) | **Cross-sandbox `yield` = 17–18 ns (~50 cycles)**; syscall 22–26 ns (**6× faster than Linux's** 129–160 ns); no hardware mode/pagetable switch (§5.3, §6.4, Table 5). |
+| Domain creation cost | lmbench lat_proc exec (platform/native) | Verification ~**34 MB/s** (each SPEC binary verifies < 0.3 s); **`fork` supported in a single address space** (CoW via Linux `memfd`). No explicit end-to-end creation-latency number (§5.2, §5.3). |
+| Inter-domain call latency | lmbench lat_pipe (platform/native) | `yield` (microkernel-like IPC) **17–18 ns (~50 cycles)** — potentially faster than optimized microkernel IPC (~400-cycle hardware limit) (§5.3, §6.4). |
+| Inter-domain throughput | lmbench bw_pipe (platform/native) | `pipe` round-trip **46–48 ns** vs Linux 1504–2494 ns and gVisor 22899 ns (§6.4, Table 5). |
+| Memory overhead per domain | MB/domain | **4 GiB virtual address space per sandbox** (+ 48 KiB guard regions), but mostly **unmapped** — physical use = actual usage. Code size: +12.9% text / +8.3% binary (§3, §6.3). |
+| Domain count bounded by | Limiting factor; approx. domain count | **Limiting factor: virtual address space** (4 GiB/sandbox). **~64Ki (2¹⁶) sandboxes** in 48-bit userspace (default ~65,000); up to **128Ki** with kernel address space (§3). |
+| Performance scales with domain count | Big O | Constant per-sandbox runtime state (reserved registers); _Inferred:_ memory O(n) in virtual space. Scales to tens of thousands of sandboxes (§3). |
+
+---
+
+## Usability / Adoptability
+
+| **Dimension** | **Metric** | **Value / Notes** |
+|----------------|------------|-------------------|
+| **Deployment Assumptions** | | |
+| What hardware does it need? | Commodity / Specialized | **ARM64 (AArch64) only** — commodity ARM (Apple M1, AWS Graviton); exploits ARM64 addressing modes. **Not x86.** SVE scatter/gather is disallowed by the verifier (§2, §6). |
+| What OS/kernel does it need? | Stock / Module / Modified / Custom | **Stock Linux** — standard page protections + signals; no kernel modifications (Asahi Linux / standard Linux in eval) (§5.3, §6). |
+| What privileges does it need? | User / Root / Kernel access | **User** — userspace sandboxing; the runtime is a normal process. (Kernel address space optionally gives 128Ki sandboxes) (§3, §5.3). |
+| Other deployment requirements | [e.g. custom libc, modified toolchain] | The LFI runtime + static verifier + **SFI-instrumented runtime libraries** (musl-libc, compiler-rt, libc++, libc++abi, libunwind) (§5.1). |
+| **Software Compatibility** | | |
+| What application changes are needed? | None / Annotations / API changes / Refactoring / Rewrite | **Recompile** through the LFI toolchain (Clang/GCC → assembly → LFI transformer → assembler), with `-ffixed-reg` flags + the SFI-instrumented musl toolchain. No source changes for most C/C++ programs (§5.1). |
+| Can it run existing binaries? | Yes / Recompile only / Source changes needed | **Recompile only** — code must be transformed + verified through the LFI toolchain; not arbitrary existing binaries (§5.1). |
+| What languages does it support? | C/C++ / Rust / Go / Managed / Any / Other | **C/C++** (LLVM/musl toolchain provided); broader feature support than Wasm — **exceptions, SIMD, setjmp/longjmp** all work; Fortran-capable. perlbench/blender need glibc (musl limitation) (§5.1, §6.2). |
+| Other compatibility notes | [Describe] | **Compiler-toolchain-independent** — operates on GNU assembly text from any toolchain (works even for hand-written `.s` files) (§5.1). |
+| **Developer Effort** | | |
+| Porting effort for typical app | [person-days] | **Recompile** via the LFI toolchain; no compiler modification needed and no source changes for compatible C/C++ — minimal, but not quantified in person-days (§5.1). |
+| Required expertise level | Low / Medium / High / Expert | **N/A** — self-report/operational dimension; not assessable by an external evaluator from the paper (policy 2026-06-09). |
+| Build effort | [build changes / time / deps] | Compile → LFI transform (~1,500 LOC tool) → assemble; link with SFI-instrumented runtime libraries (§5.1). |
+| **Developer Experience** | | |
+| Debugging support | Standard / Custom / Limited | **N/A** — self-report/operational dimension; not assessable by an external evaluator from the paper (policy 2026-06-09). |
+| Failure modes visibility | [crashes/logs/error codes/silent] | Out-of-bounds access → **trap** (unmapped guard region → page-fault → runtime signal); the verifier **rejects** unsafe binaries at load (§3, §5.2, §5.3). |
+| **Availability** | | |
+| License | Open source / Closed / Commercial / Other | **Open source — MPL 2.0** (paper Artifact A.2: "Code licenses: MPL 2.0") [repo] `github.com/zyedidia/lfi` (+ `lfi-artifact`). Paper licensed CC-BY 4.0. |
+| Primary usage | Production / Research / Internal / Experimental / Other | **Research** — prototype oriented toward cloud/serverless adoption (§1, §6). |
+
+---
+
+## Composability
+
+| **Dimension** | **Metric** | **Value / Notes** |
+|----------------|------------|-------------------|
+| **Cross-Framework Composability** | | |
+| Integrates with other compartmentalization mechanisms | ✅ / ❌ | _Inferred:_ **✅** — composes with virtualization/containers (can run inside a VM) and can use ARM extensions (CSV2_2 for Spectre); future hardware-SFI support discussed (§6.4, §7.1, §7.3). |
+| Can coexist with other compartmentalization systems | ✅ / ❌ | **✅** — tens of thousands of sandboxes + the runtime coexist in one process; runs as a normal Linux process (§3, §5.3). |
+| Can stack effectively | ✅ / ❌ | **✅** — up to ~64Ki sandboxes compose in one address space (§3). |
+| **Inter-Compartment Interactions** | | |
+| How compartments invoke each other | Function calls / Message passing / RPC / Syscalls / Other | **Function calls** — fast cross-sandbox `yield` (~50 cycles, microkernel-like IPC); runtime calls via an in-sandbox call table (no trampoline) (§4.4, §5.3). |
+| How compartments share data | Shared memory / Message passing / Serialization / Other | **Message passing** (pipes) + runtime-mediated; the **"no-loads" mode permits read-only cross-sandbox reads**; shared memory possible via the runtime (§5.3, §6.1). |
+| Interaction semantics | Synchronous / Asynchronous / Both | **Synchronous** (`yield` / runtime calls); preemption is signal-driven (§5.3). |
+| Interaction security/validation | [Describe] | The runtime mediates calls + checks arguments; the static verifier guarantees isolation invariants (§5.2, §5.3). |
+| **Decomposition Model** | | |
+| Decomposition boundary | Library / Service / Thread / Process / VM / Other | **Sandbox** — a process-like 4 GiB region (§3). |
+| Who defines boundaries | Programmer / Compiler / Runtime / Kernel / Hardware | **Runtime/loader** loads verified ELFs into 4 GiB slots; the programmer structures programs into sandboxes (§5.3). |
+| Boundaries flexible at runtime | ✅ / ❌ | **✅** — sandboxes are loaded dynamically and `fork` is supported (CoW); the size is fixed at 4 GiB (§3, §5.3). |
+| **System Integration** | | |
+| Threading model | Standard threads / Custom threading / Other | Runtime-managed scheduling with **signal-based preemption** (`setitimer`); reserved registers per sandbox (§5.3). |
+| Process model | fork/exec / Custom / N/A | **✅ Unix-like process model** — the runtime implements `open`/`read`/`write`/`fork`/`wait`/`pipe`/`mmap` within one Linux process; `fork` works in a single address space (§5.3). |
+| POSIX compatibility | Full / Partial / Limited | **Partial (good)** — the runtime provides a small Unix-like OS; musl libc (some glibc-specific programs unsupported) (§5.3, §6). |
+| **Composition Limitations** | | |
+| Known limitations when composed | [Describe] | ARM64 only; **4 GiB max per sandbox** (SPECspeed >4 GiB excluded); SVE scatter/gather disallowed; glibc-specific programs unsupported (musl) (§2, §6). |
+| Security caveats when layered | [Describe] | Full Spectre poisoning mitigation needs ARM CSV2_2 (Cortex-X2+, not universal); the verifier's external disassembler deps are in the TCB; the "no-loads" mode deliberately allows cross-sandbox reads (§5.2, §7.1). |
+
+---
+
+## System Design & Operations
+
+| **Dimension** | **Metric** | **Value / Notes** |
+|----------------|------------|-------------------|
+| **Target Environment** | | |
+| Primary deployment target | Embedded / IoT / Cloud / Server / Desktop / Other | **Cloud / Server** — cloud, serverless, edge; many short-lived untrusted programs with low latency (§1). |
+| Deployment scale | Single device / Cluster / Large scale | **Large scale** — tens of thousands of sandboxes per process (§1, §3). |
+| **Integration** | | |
+| Monitoring/orchestration support | Good / Limited / None | **N/A** — self-report/operational dimension; not assessable by an external evaluator from the paper (policy 2026-06-09). |
+| **Operations** | | |
+| Initial configuration complexity | Low / Medium / High | **N/A** — self-report/operational dimension; not assessable by an external evaluator from the paper (policy 2026-06-09). |
+| Ongoing maintenance burden | Low / Medium / High | **N/A** — self-report/operational dimension; not assessable by an external evaluator from the paper (policy 2026-06-09). |
+
+---
+
+## Summary
+
+> **What it is:** The first software fault isolation (SFI) scheme for **ARM64** — it sandboxes untrusted code by rewriting loads, stores, and jumps with cheap guard instructions (exploiting ARM64 addressing modes for ~0–1 cycle guards), supports **tens of thousands of 4 GiB sandboxes in one address space** with fast (~50-cycle) context switches, and uses a small **static machine-code verifier** to keep the TCB tiny (no trusted compiler).
+>
+> **Who it's for:** Cloud/serverless/edge platforms running many short-lived untrusted programs that need both low CPU overhead *and* fast context switches, on ARM64.
+>
+> **What it protects:** Each sandbox from the others — full software isolation of loads/stores/jumps within a 4 GiB region (or stores+jumps only in the lighter compartmentalization mode).
+>
+> **What it costs (effort/money/performance):** 6.4–7.3% runtime overhead on SPEC 2017 (~1% for stores+jumps only), ~13% code size; recompilation through the LFI toolchain; ARM64 only.
+>
+> **What it needs (hardware/OS/expertise):** Commodity ARM64, stock Linux, the LFI runtime + verifier + SFI-instrumented musl toolchain; ARM CSV2_2 for full Spectre mitigation.
+>
+> **Key tradeoffs:** Near-virtualization CPU overhead *with* microkernel-beating context-switch speed and a tiny verifier-based TCB, plus broad software support (exceptions/SIMD/setjmp) and Spectre-breakout safety by construction — but it is ARM64-only, capped at 4 GiB per sandbox, requires recompilation, and full Spectre-poisoning mitigation needs a recent ARM extension.
+>
+> **Additional Notes:** A strong, well-rounded SFI data point — directly comparable to **HFI** (proposed hardware) and **Occlum's MMDSFI** (x86/MPX), but pure-software on commodity ARM64. The "verifier keeps the compiler out of the TCB" idea mirrors Occlum; the toolchain-independence is a notable maintainability advantage.
+
+---
+
+## Sources
+
+- **Primary:** `papers/lfi.pdf` — Z. Yedidia, *Lightweight Fault Isolation: Practical, Efficient, and Secure Software Sandboxing*, ASPLOS 2024, DOI 10.1145/3620665.3640408. All **(§N)** / Table / Figure citations reference this paper. (Read via extracted text — `pdftotext`.)
+- License: paper Artifact A.2 = **MPL 2.0**; **[repo]** `github.com/zyedidia/lfi` (+ `github.com/zyedidia/lfi-artifact`). Paper licensed CC-BY 4.0.
+
+### Cells flagged for further research
+- **Usability › Debugging support** — not directly discussed.
+- **Efficiency › Domain creation cost** — verification rate given, but no end-to-end sandbox-creation latency.
+- **Sys Design › Monitoring/orchestration** — runtime scheduler only; no orchestration described.
+- Rating/classification inferences (crash isolation, integrates-with-other, required expertise, config complexity, maintenance, memory Big-O) marked `_Inferred:_` inline.

--- a/evaluations/lfi.md
+++ b/evaluations/lfi.md
@@ -1,16 +1,11 @@
 # Compartmentalization Evaluation Matrix — LFI
 
+**Version:** v0.1
 **System:** LFI (Lightweight Fault Isolation) — an SFI scheme for ARM64
-**Paper:** Z. Yedidia. *Lightweight Fault Isolation: Practical, Efficient, and Secure Software Sandboxing.* ASPLOS 2024. DOI 10.1145/3620665.3640408.
-**Source file:** `papers/lfi.pdf`
-**Matrix version:** v0.1
-**Evaluated:** 2026-06-08
+**Paper:** Z. Yedidia. Lightweight Fault Isolation: Practical, Efficient, and Secure Software Sandboxing. ASPLOS 2024. DOI 10.1145/3620665.3640408.
 
-> ✅ / ❌ for checkboxes; categorical scales and short text otherwise.
->
-> **Sourcing legend:** **(§N)** = stated in paper · **[repo]** = from git repo/site · **_Inferred:_** = evaluator assessment, not a paper claim · **⚠️ Unclear** = not found, needs research.
->
-> _Compartment = a **sandbox**: an aligned 4 GiB region in a shared address space, into which untrusted code is loaded after a static machine-code verifier confirms its loads/stores/jumps are guarded. Pure software fault isolation (SFI), no hardware isolation primitive._
+> Complete this matrix for a single implementation or system.
+> Use ✅ / ❌ for checkboxes, categorical scales, and short text values as indicated.
 
 ---
 
@@ -19,28 +14,28 @@
 | **Dimension** | **Metric** | **Value / Notes** |
 |----------------|------------|-------------------|
 | **Isolation Model** | | |
-| Primary use case | Untrusted component isolation / Secret protection / Fault isolation / Other | **Untrusted component isolation** — sandboxing untrusted code with low latency for cloud/serverless; a lighter "stores+jumps only" mode targets **fault isolation / software compartmentalization** (read-only cross-sandbox) (Abstract, §1, §6.1). |
-| Subject selection | Code-centric / Data-centric / Hybrid | **Code-centric** — sandboxes code (an untrusted program/module) (§3). |
-| Code-centric granularity | Function / Library / Thread / Process / VM / N/A | **Process-like sandbox** — a 4 GiB isolation domain holding a program, in a shared address space (§3, Fig. 1). |
+| Primary use case | Untrusted component isolation / Secret protection / Fault isolation / Other | **Untrusted component isolation** — sandboxing untrusted code with low latency for cloud/serverless; a lighter "stores+jumps only" mode targets **fault isolation / software compartmentalization** (read-only cross-sandbox). |
+| Subject selection | Code-centric / Data-centric / Hybrid | **Code-centric** — sandboxes code (an untrusted program/module). |
+| Code-centric granularity | Function / Library / Thread / Process / VM / N/A | **Process-like sandbox** — a 4 GiB isolation domain holding a program, in a shared address space. |
 | Data-centric granularity | Object / Region / Page / Allocation / File / N/A | **N/A** — isolation is per-4 GiB-region. |
 | **Isolation Approach** | | |
-| Hardware primitive(s) | MPK/PKU / MTE / CHERI / TEEs / Other / None | **None** — classic SFI via software guard instructions; uses only **standard page protections (W⊕X), set once at init** (no per-switch hardware involvement) (§3). |
-| Software technique(s) | SFI / Boundary wrappers/marshalling / Memory-safe language / Language runtime / Other / None | **SFI** — guard instructions on loads/stores/jumps (exploiting ARM64 addressing modes for ~0–1 cycle guards) + a **static machine-code verifier** (§3, §4, §5.2). |
-| Isolation abstraction | Process / Thread / Intra-Address Space Domain / VM / Container / Other | **Intra-Address Space Domain** — tens of thousands of sandboxes in one address space (§1, §3). |
-| Requires runtime software support | ✅ / ❌ (describe) | **✅** — a runtime (manages sandboxes, mediated runtime calls, scheduling, fast IPC), the static verifier, and the LFI assembly transformer (§5). |
+| Hardware primitive(s) | MPK/PKU / MTE / CHERI / TEEs / Other / None | **None** — classic SFI via software guard instructions; uses only **standard page protections (W⊕X), set once at init** (no per-switch hardware involvement). |
+| Software technique(s) | SFI / Boundary wrappers/marshalling / Memory-safe language / Language runtime / Other / None | **SFI** — guard instructions on loads/stores/jumps (exploiting ARM64 addressing modes for ~0–1 cycle guards) + a **static machine-code verifier**. |
+| Isolation abstraction | Process / Thread / Intra-Address Space Domain / VM / Container / Other | **Intra-Address Space Domain** — tens of thousands of sandboxes in one address space. |
+| Requires runtime software support | ✅ / ❌ (describe) | **✅** — a runtime (manages sandboxes, mediated runtime calls, scheduling, fast IPC), the static verifier, and the LFI assembly transformer. |
 | **Properties Enforced** | | |
-| Security properties provided | [Describe] | **Full software isolation of loads, stores, and jumps** — a sandbox cannot read/write/jump outside its 4 GiB region (the static verifier guarantees the reserved-register + guard invariants); plus a "no-loads" mode (stores+jumps only) that permits read-only cross-sandbox access for compartmentalization; Spectre-breakout safety by construction (§3, §5.2, §6.1, §7.1). |
+| Security properties provided | [Describe] | **Full software isolation of loads, stores, and jumps** — a sandbox cannot read/write/jump outside its 4 GiB region (the static verifier guarantees the reserved-register + guard invariants); plus a "no-loads" mode (stores+jumps only) that permits read-only cross-sandbox access for compartmentalization; Spectre-breakout safety by construction. |
 | **Resilience** | | |
-| Compartment crashes isolated | ✅ / ❌ | _Inferred:_ **✅** — out-of-bounds accesses hit unmapped guard regions and **trap** (page fault → signal to the runtime); the runtime mediates and schedules sandboxes (§3, §5.3). Not framed as an explicit recovery experiment. |
+| Compartment crashes isolated | ✅ / ❌ | **✅** — out-of-bounds accesses hit unmapped guard regions and **trap** (page fault → signal to the runtime); the runtime mediates and schedules sandboxes. Not framed as an explicit recovery experiment. |
 | **Interface Safety** | | |
-| Provides means to facilitate boundary checking/validation | ✅ / ❌ / Partial | **✅** — the runtime mediates all runtime calls and **checks arguments** (e.g., can disallow access to certain directories); the static verifier rejects any binary using unsafe instructions/addressing (§5.2, §5.3). |
+| Provides means to facilitate boundary checking/validation | ✅ / ❌ / Partial | **✅** — the runtime mediates all runtime calls and **checks arguments** (e.g., can disallow access to certain directories); the static verifier rejects any binary using unsafe instructions/addressing. |
 | **Trust & Threats** | | |
-| TCB includes | Compiler / OS / Firmware / CPU / Other (list) | **Static verifier** (+ its disassembler/ELF-reader/instruction-def dependencies), the **runtime**, and the **OS/CPU**. The **compiler and the LFI assembly transformer are NOT trusted** — the verifier checks the final machine code (§5.1, §5.2). |
-| TCB approximate size | Small / Medium / Large / Very Large or [LOC] | **Small** — verifier **core = 300 LOC Rust** (excludes LLVM's ~2M LOC from the TCB), though external deps (Binary Ninja disassembler, ELF reader, instruction defs) are "larger than we'd like." The LFI transformer (~1,500 LOC) is outside the TCB (§5.1, §5.2). |
-| Side-channel resistance | Cache / Timing / Speculative / Other / None (mitigations) | **✅ (partial, Spectre)** — **sandbox-breakout mitigated by construction** (LFI relies on no fine-grained CFI; all jumps are data-flow-guarded, so speculative jumps stay in-sandbox). Cross-sandbox / host **poisoning** needs ARM's **CSV2_2** extension (Cortex-X2+, not universal) (§7.1). Stronger than most software systems in this set. |
+| TCB includes | Compiler / OS / Firmware / CPU / Other (list) | **Static verifier** (+ its disassembler/ELF-reader/instruction-def dependencies), the **runtime**, and the **OS/CPU**. The **compiler and the LFI assembly transformer are NOT trusted** — the verifier checks the final machine code. |
+| TCB approximate size | Small / Medium / Large / Very Large or [LOC] | **Small** — verifier **core = 300 LOC Rust** (excludes LLVM's ~2M LOC from the TCB), though external deps (Binary Ninja disassembler, ELF reader, instruction defs) are larger than we'd like. The LFI transformer (~1,500 LOC) is outside the TCB. |
+| Side-channel resistance | Cache / Timing / Speculative / Other / None (mitigations) | **✅ (partial, Spectre)** — **sandbox-breakout mitigated by construction** (LFI relies on no fine-grained CFI; all jumps are data-flow-guarded, so speculative jumps stay in-sandbox). Cross-sandbox / host **poisoning** needs ARM's **CSV2_2** extension (Cortex-X2+, not universal). Stronger than most software systems in this set. |
 | **Validation** | | |
-| Formal validation available | Yes (specify) / No | **No** formal proof — but the verifier's disassembler/instruction definitions are auto-generated from **Arm's Machine Readable Specification (MRS)**, a formal ISA spec (§5.2). |
-| Experimental validation available | Yes (specify) / No | **Yes** — SPEC CPU 2017 (14 benchmarks), comparison vs Wasm engines (Wasmtime/Wasm2c/WAMR), vs hardware virtualization (KVM) + gVisor, context-switch microbenchmarks, and a Spectre analysis. Hosts: Apple M1 (Asahi Linux) + GCP T2A (§6). Artifact (MPL 2.0). |
+| Formal validation available | Yes (specify) / No | **No** formal proof — but the verifier's disassembler/instruction definitions are auto-generated from **Arm's Machine Readable Specification (MRS)**, a formal ISA spec. |
+| Experimental validation available | Yes (specify) / No | **Yes** — SPEC CPU 2017 (14 benchmarks), comparison vs Wasm engines (Wasmtime/Wasm2c/WAMR), vs hardware virtualization (KVM) + gVisor, context-switch microbenchmarks, and a Spectre analysis. Hosts: Apple M1 (Asahi Linux) + GCP T2A. Artifact (MPL 2.0). |
 
 ---
 
@@ -48,14 +43,14 @@
 
 | **Dimension** | **Metric** | **Value / Notes** |
 |----------------|------------|-------------------|
-| General runtime overhead | SPEC 2017 (platform/native) | **SPEC 2017**: geomean **6.4% (Apple M1) / 7.3% (GCP T2A)** for full isolation (O2); **~1%** for the stores+jumps-only ("no loads") mode; worst single benchmark 17% (leela). vs Wasm: roughly **half** Wasm's overhead (WAMR 18–22%, Wasm2c-pinned 16%, Wasmtime 47–67%) (§6.1–6.2, Tables 4). |
-| Domain switch cost | lmbench lat_ctx (platform/native) | **Cross-sandbox `yield` = 17–18 ns (~50 cycles)**; syscall 22–26 ns (**6× faster than Linux's** 129–160 ns); no hardware mode/pagetable switch (§5.3, §6.4, Table 5). |
-| Domain creation cost | lmbench lat_proc exec (platform/native) | Verification ~**34 MB/s** (each SPEC binary verifies < 0.3 s); **`fork` supported in a single address space** (CoW via Linux `memfd`). No explicit end-to-end creation-latency number (§5.2, §5.3). |
-| Inter-domain call latency | lmbench lat_pipe (platform/native) | `yield` (microkernel-like IPC) **17–18 ns (~50 cycles)** — potentially faster than optimized microkernel IPC (~400-cycle hardware limit) (§5.3, §6.4). |
-| Inter-domain throughput | lmbench bw_pipe (platform/native) | `pipe` round-trip **46–48 ns** vs Linux 1504–2494 ns and gVisor 22899 ns (§6.4, Table 5). |
-| Memory overhead per domain | MB/domain | **4 GiB virtual address space per sandbox** (+ 48 KiB guard regions), but mostly **unmapped** — physical use = actual usage. Code size: +12.9% text / +8.3% binary (§3, §6.3). |
-| Domain count bounded by | Limiting factor; approx. domain count | **Limiting factor: virtual address space** (4 GiB/sandbox). **~64Ki (2¹⁶) sandboxes** in 48-bit userspace (default ~65,000); up to **128Ki** with kernel address space (§3). |
-| Performance scales with domain count | Big O | Constant per-sandbox runtime state (reserved registers); _Inferred:_ memory O(n) in virtual space. Scales to tens of thousands of sandboxes (§3). |
+| General runtime overhead | SPEC 2017 (platform/native) | **SPEC 2017**: geomean **6.4% (Apple M1) / 7.3% (GCP T2A)** for full isolation (O2); **~1%** for the stores+jumps-only ("no loads") mode; worst single benchmark 17% (leela). vs Wasm: roughly **half** Wasm's overhead (WAMR 18–22%, Wasm2c-pinned 16%, Wasmtime 47–67%). |
+| Domain switch cost | lmbench lat_ctx (platform/native) | **Cross-sandbox `yield` = 17–18 ns (~50 cycles)**; syscall 22–26 ns (**6× faster than Linux's** 129–160 ns); no hardware mode/pagetable switch. |
+| Domain creation cost | lmbench lat_proc exec (platform/native) | Verification ~**34 MB/s** (each SPEC binary verifies < 0.3 s); **`fork` supported in a single address space** (CoW via Linux `memfd`). No explicit end-to-end creation-latency number. |
+| Inter-domain call latency | lmbench lat_pipe (platform/native) | `yield` (microkernel-like IPC) **17–18 ns (~50 cycles)** — potentially faster than optimized microkernel IPC (~400-cycle hardware limit). |
+| Inter-domain throughput | lmbench bw_pipe (platform/native) | `pipe` round-trip **46–48 ns** vs Linux 1504–2494 ns and gVisor 22899 ns. |
+| Memory overhead per domain | MB/domain | **4 GiB virtual address space per sandbox** (+ 48 KiB guard regions), but mostly **unmapped** — physical use = actual usage. Code size: +12.9% text / +8.3% binary. |
+| Domain count bounded by | Limiting factor; approx. domain count | **Limiting factor: virtual address space** (4 GiB/sandbox). **~64Ki (2¹⁶) sandboxes** in 48-bit userspace (default ~65,000); up to **128Ki** with kernel address space. |
+| Performance scales with domain count | Big O | Constant per-sandbox runtime state (reserved registers); memory O(n) in virtual space. Scales to tens of thousands of sandboxes. |
 
 ---
 
@@ -64,25 +59,25 @@
 | **Dimension** | **Metric** | **Value / Notes** |
 |----------------|------------|-------------------|
 | **Deployment Assumptions** | | |
-| What hardware does it need? | Commodity / Specialized | **ARM64 (AArch64) only** — commodity ARM (Apple M1, AWS Graviton); exploits ARM64 addressing modes. **Not x86.** SVE scatter/gather is disallowed by the verifier (§2, §6). |
-| What OS/kernel does it need? | Stock / Module / Modified / Custom | **Stock Linux** — standard page protections + signals; no kernel modifications (Asahi Linux / standard Linux in eval) (§5.3, §6). |
-| What privileges does it need? | User / Root / Kernel access | **User** — userspace sandboxing; the runtime is a normal process. (Kernel address space optionally gives 128Ki sandboxes) (§3, §5.3). |
-| Other deployment requirements | [e.g. custom libc, modified toolchain] | The LFI runtime + static verifier + **SFI-instrumented runtime libraries** (musl-libc, compiler-rt, libc++, libc++abi, libunwind) (§5.1). |
+| What hardware does it need? | Commodity / Specialized | **ARM64 (AArch64) only** — commodity ARM (Apple M1, AWS Graviton); exploits ARM64 addressing modes. **Not x86.** SVE scatter/gather is disallowed by the verifier. |
+| What OS/kernel does it need? | Stock / Module / Modified / Custom | **Stock Linux** — standard page protections + signals; no kernel modifications (Asahi Linux / standard Linux in eval). |
+| What privileges does it need? | User / Root / Kernel access | **User** — userspace sandboxing; the runtime is a normal process. (Kernel address space optionally gives 128Ki sandboxes). |
+| Other deployment requirements | [e.g. custom libc, modified toolchain] | The LFI runtime + static verifier + **SFI-instrumented runtime libraries** (musl-libc, compiler-rt, libc++, libc++abi, libunwind). |
 | **Software Compatibility** | | |
-| What application changes are needed? | None / Annotations / API changes / Refactoring / Rewrite | **Recompile** through the LFI toolchain (Clang/GCC → assembly → LFI transformer → assembler), with `-ffixed-reg` flags + the SFI-instrumented musl toolchain. No source changes for most C/C++ programs (§5.1). |
-| Can it run existing binaries? | Yes / Recompile only / Source changes needed | **Recompile only** — code must be transformed + verified through the LFI toolchain; not arbitrary existing binaries (§5.1). |
-| What languages does it support? | C/C++ / Rust / Go / Managed / Any / Other | **C/C++** (LLVM/musl toolchain provided); broader feature support than Wasm — **exceptions, SIMD, setjmp/longjmp** all work; Fortran-capable. perlbench/blender need glibc (musl limitation) (§5.1, §6.2). |
-| Other compatibility notes | [Describe] | **Compiler-toolchain-independent** — operates on GNU assembly text from any toolchain (works even for hand-written `.s` files) (§5.1). |
+| What application changes are needed? | None / Annotations / API changes / Refactoring / Rewrite | **Recompile** through the LFI toolchain (Clang/GCC → assembly → LFI transformer → assembler), with `-ffixed-reg` flags + the SFI-instrumented musl toolchain. No source changes for most C/C++ programs. |
+| Can it run existing binaries? | Yes / Recompile only / Source changes needed | **Recompile only** — code must be transformed + verified through the LFI toolchain; not arbitrary existing binaries. |
+| What languages does it support? | C/C++ / Rust / Go / Managed / Any / Other | **C/C++** (LLVM/musl toolchain provided); broader feature support than Wasm — **exceptions, SIMD, setjmp/longjmp** all work; Fortran-capable. perlbench/blender need glibc (musl limitation). |
+| Other compatibility notes | [Describe] | **Compiler-toolchain-independent** — operates on GNU assembly text from any toolchain (works even for hand-written `.s` files). |
 | **Developer Effort** | | |
-| Porting effort for typical app | [person-days] | **Recompile** via the LFI toolchain; no compiler modification needed and no source changes for compatible C/C++ — minimal, but not quantified in person-days (§5.1). |
-| Required expertise level | Low / Medium / High / Expert | **N/A** — self-report/operational dimension; not assessable by an external evaluator from the paper (policy 2026-06-09). |
-| Build effort | [build changes / time / deps] | Compile → LFI transform (~1,500 LOC tool) → assemble; link with SFI-instrumented runtime libraries (§5.1). |
+| Porting effort for typical app | [person-days] | **Recompile** via the LFI toolchain; no compiler modification needed and no source changes for compatible C/C++ — minimal, but not quantified in person-days. |
+| Required expertise level | Low / Medium / High / Expert | **N/A** — self-report/operational dimension; not assessable by an external evaluator from the paper. |
+| Build effort | [build changes / time / deps] | Compile → LFI transform (~1,500 LOC tool) → assemble; link with SFI-instrumented runtime libraries. |
 | **Developer Experience** | | |
-| Debugging support | Standard / Custom / Limited | **N/A** — self-report/operational dimension; not assessable by an external evaluator from the paper (policy 2026-06-09). |
-| Failure modes visibility | [crashes/logs/error codes/silent] | Out-of-bounds access → **trap** (unmapped guard region → page-fault → runtime signal); the verifier **rejects** unsafe binaries at load (§3, §5.2, §5.3). |
+| Debugging support | Standard / Custom / Limited | **N/A** — self-report/operational dimension; not assessable by an external evaluator from the paper. |
+| Failure modes visibility | [crashes/logs/error codes/silent] | Out-of-bounds access → **trap** (unmapped guard region → page-fault → runtime signal); the verifier **rejects** unsafe binaries at load. |
 | **Availability** | | |
-| License | Open source / Closed / Commercial / Other | **Open source — MPL 2.0** (paper Artifact A.2: "Code licenses: MPL 2.0") [repo] `github.com/zyedidia/lfi` (+ `lfi-artifact`). Paper licensed CC-BY 4.0. |
-| Primary usage | Production / Research / Internal / Experimental / Other | **Research** — prototype oriented toward cloud/serverless adoption (§1, §6). |
+| License | Open source / Closed / Commercial / Other | **Open source — MPL 2.0** (paper Artifact A.2: "Code licenses: MPL 2.0") `github.com/zyedidia/lfi` (+ `lfi-artifact`). Paper licensed CC-BY 4.0. |
+| Primary usage | Production / Research / Internal / Experimental / Other | **Research** — prototype oriented toward cloud/serverless adoption. |
 
 ---
 
@@ -91,25 +86,25 @@
 | **Dimension** | **Metric** | **Value / Notes** |
 |----------------|------------|-------------------|
 | **Cross-Framework Composability** | | |
-| Integrates with other compartmentalization mechanisms | ✅ / ❌ | _Inferred:_ **✅** — composes with virtualization/containers (can run inside a VM) and can use ARM extensions (CSV2_2 for Spectre); future hardware-SFI support discussed (§6.4, §7.1, §7.3). |
-| Can coexist with other compartmentalization systems | ✅ / ❌ | **✅** — tens of thousands of sandboxes + the runtime coexist in one process; runs as a normal Linux process (§3, §5.3). |
-| Can stack effectively | ✅ / ❌ | **✅** — up to ~64Ki sandboxes compose in one address space (§3). |
+| Integrates with other compartmentalization mechanisms | ✅ / ❌ | **✅** — composes with virtualization/containers (can run inside a VM) and can use ARM extensions (CSV2_2 for Spectre); future hardware-SFI support discussed. |
+| Can coexist with other compartmentalization systems | ✅ / ❌ | **✅** — tens of thousands of sandboxes + the runtime coexist in one process; runs as a normal Linux process. |
+| Can stack effectively | ✅ / ❌ | **✅** — up to ~64Ki sandboxes compose in one address space. |
 | **Inter-Compartment Interactions** | | |
-| How compartments invoke each other | Function calls / Message passing / RPC / Syscalls / Other | **Function calls** — fast cross-sandbox `yield` (~50 cycles, microkernel-like IPC); runtime calls via an in-sandbox call table (no trampoline) (§4.4, §5.3). |
-| How compartments share data | Shared memory / Message passing / Serialization / Other | **Message passing** (pipes) + runtime-mediated; the **"no-loads" mode permits read-only cross-sandbox reads**; shared memory possible via the runtime (§5.3, §6.1). |
-| Interaction semantics | Synchronous / Asynchronous / Both | **Synchronous** (`yield` / runtime calls); preemption is signal-driven (§5.3). |
-| Interaction security/validation | [Describe] | The runtime mediates calls + checks arguments; the static verifier guarantees isolation invariants (§5.2, §5.3). |
+| How compartments invoke each other | Function calls / Message passing / RPC / Syscalls / Other | **Function calls** — fast cross-sandbox `yield` (~50 cycles, microkernel-like IPC); runtime calls via an in-sandbox call table (no trampoline). |
+| How compartments share data | Shared memory / Message passing / Serialization / Other | **Message passing** (pipes) + runtime-mediated; the **"no-loads" mode permits read-only cross-sandbox reads**; shared memory possible via the runtime. |
+| Interaction semantics | Synchronous / Asynchronous / Both | **Synchronous** (`yield` / runtime calls); preemption is signal-driven. |
+| Interaction security/validation | [Describe] | The runtime mediates calls + checks arguments; the static verifier guarantees isolation invariants. |
 | **Decomposition Model** | | |
-| Decomposition boundary | Library / Service / Thread / Process / VM / Other | **Sandbox** — a process-like 4 GiB region (§3). |
-| Who defines boundaries | Programmer / Compiler / Runtime / Kernel / Hardware | **Runtime/loader** loads verified ELFs into 4 GiB slots; the programmer structures programs into sandboxes (§5.3). |
-| Boundaries flexible at runtime | ✅ / ❌ | **✅** — sandboxes are loaded dynamically and `fork` is supported (CoW); the size is fixed at 4 GiB (§3, §5.3). |
+| Decomposition boundary | Library / Service / Thread / Process / VM / Other | **Sandbox** — a process-like 4 GiB region. |
+| Who defines boundaries | Programmer / Compiler / Runtime / Kernel / Hardware | **Runtime/loader** loads verified ELFs into 4 GiB slots; the programmer structures programs into sandboxes. |
+| Boundaries flexible at runtime | ✅ / ❌ | **✅** — sandboxes are loaded dynamically and `fork` is supported (CoW); the size is fixed at 4 GiB. |
 | **System Integration** | | |
-| Threading model | Standard threads / Custom threading / Other | Runtime-managed scheduling with **signal-based preemption** (`setitimer`); reserved registers per sandbox (§5.3). |
-| Process model | fork/exec / Custom / N/A | **✅ Unix-like process model** — the runtime implements `open`/`read`/`write`/`fork`/`wait`/`pipe`/`mmap` within one Linux process; `fork` works in a single address space (§5.3). |
-| POSIX compatibility | Full / Partial / Limited | **Partial (good)** — the runtime provides a small Unix-like OS; musl libc (some glibc-specific programs unsupported) (§5.3, §6). |
+| Threading model | Standard threads / Custom threading / Other | Runtime-managed scheduling with **signal-based preemption** (`setitimer`); reserved registers per sandbox. |
+| Process model | fork/exec / Custom / N/A | **✅ Unix-like process model** — the runtime implements `open`/`read`/`write`/`fork`/`wait`/`pipe`/`mmap` within one Linux process; `fork` works in a single address space. |
+| POSIX compatibility | Full / Partial / Limited | **Partial (good)** — the runtime provides a small Unix-like OS; musl libc (some glibc-specific programs unsupported). |
 | **Composition Limitations** | | |
-| Known limitations when composed | [Describe] | ARM64 only; **4 GiB max per sandbox** (SPECspeed >4 GiB excluded); SVE scatter/gather disallowed; glibc-specific programs unsupported (musl) (§2, §6). |
-| Security caveats when layered | [Describe] | Full Spectre poisoning mitigation needs ARM CSV2_2 (Cortex-X2+, not universal); the verifier's external disassembler deps are in the TCB; the "no-loads" mode deliberately allows cross-sandbox reads (§5.2, §7.1). |
+| Known limitations when composed | [Describe] | ARM64 only; **4 GiB max per sandbox** (SPECspeed >4 GiB excluded); SVE scatter/gather disallowed; glibc-specific programs unsupported (musl). |
+| Security caveats when layered | [Describe] | Full Spectre poisoning mitigation needs ARM CSV2_2 (Cortex-X2+, not universal); the verifier's external disassembler deps are in the TCB; the "no-loads" mode deliberately allows cross-sandbox reads. |
 
 ---
 
@@ -118,13 +113,13 @@
 | **Dimension** | **Metric** | **Value / Notes** |
 |----------------|------------|-------------------|
 | **Target Environment** | | |
-| Primary deployment target | Embedded / IoT / Cloud / Server / Desktop / Other | **Cloud / Server** — cloud, serverless, edge; many short-lived untrusted programs with low latency (§1). |
-| Deployment scale | Single device / Cluster / Large scale | **Large scale** — tens of thousands of sandboxes per process (§1, §3). |
+| Primary deployment target | Embedded / IoT / Cloud / Server / Desktop / Other | **Cloud / Server** — cloud, serverless, edge; many short-lived untrusted programs with low latency. |
+| Deployment scale | Single device / Cluster / Large scale | **Large scale** — tens of thousands of sandboxes per process. |
 | **Integration** | | |
-| Monitoring/orchestration support | Good / Limited / None | **N/A** — self-report/operational dimension; not assessable by an external evaluator from the paper (policy 2026-06-09). |
+| Monitoring/orchestration support | Good / Limited / None | **N/A** — self-report/operational dimension; not assessable by an external evaluator from the paper. |
 | **Operations** | | |
-| Initial configuration complexity | Low / Medium / High | **N/A** — self-report/operational dimension; not assessable by an external evaluator from the paper (policy 2026-06-09). |
-| Ongoing maintenance burden | Low / Medium / High | **N/A** — self-report/operational dimension; not assessable by an external evaluator from the paper (policy 2026-06-09). |
+| Initial configuration complexity | Low / Medium / High | **N/A** — self-report/operational dimension; not assessable by an external evaluator from the paper. |
+| Ongoing maintenance burden | Low / Medium / High | **N/A** — self-report/operational dimension; not assessable by an external evaluator from the paper. |
 
 ---
 
@@ -143,16 +138,3 @@
 > **Key tradeoffs:** Near-virtualization CPU overhead *with* microkernel-beating context-switch speed and a tiny verifier-based TCB, plus broad software support (exceptions/SIMD/setjmp) and Spectre-breakout safety by construction — but it is ARM64-only, capped at 4 GiB per sandbox, requires recompilation, and full Spectre-poisoning mitigation needs a recent ARM extension.
 >
 > **Additional Notes:** A strong, well-rounded SFI data point — directly comparable to **HFI** (proposed hardware) and **Occlum's MMDSFI** (x86/MPX), but pure-software on commodity ARM64. The "verifier keeps the compiler out of the TCB" idea mirrors Occlum; the toolchain-independence is a notable maintainability advantage.
-
----
-
-## Sources
-
-- **Primary:** `papers/lfi.pdf` — Z. Yedidia, *Lightweight Fault Isolation: Practical, Efficient, and Secure Software Sandboxing*, ASPLOS 2024, DOI 10.1145/3620665.3640408. All **(§N)** / Table / Figure citations reference this paper. (Read via extracted text — `pdftotext`.)
-- License: paper Artifact A.2 = **MPL 2.0**; **[repo]** `github.com/zyedidia/lfi` (+ `github.com/zyedidia/lfi-artifact`). Paper licensed CC-BY 4.0.
-
-### Cells flagged for further research
-- **Usability › Debugging support** — not directly discussed.
-- **Efficiency › Domain creation cost** — verification rate given, but no end-to-end sandbox-creation latency.
-- **Sys Design › Monitoring/orchestration** — runtime scheduler only; no orchestration described.
-- Rating/classification inferences (crash isolation, integrates-with-other, required expertise, config complexity, maintenance, memory Big-O) marked `_Inferred:_` inline.

--- a/evaluations/lfi.md
+++ b/evaluations/lfi.md
@@ -1,7 +1,7 @@
 # Compartmentalization Evaluation Matrix — LFI
 
 **Version:** v0.1
-**System:** LFI (Lightweight Fault Isolation) — an SFI scheme for ARM64
+**System:** LFI (Lightweight Fault Isolation) — an SFI scheme, originally for AArch64 and since extended to x86-64
 **Paper:** Z. Yedidia. Lightweight Fault Isolation: Practical, Efficient, and Secure Software Sandboxing. ASPLOS 2024. DOI 10.1145/3620665.3640408.
 
 > Complete this matrix for a single implementation or system.
@@ -26,7 +26,7 @@
 | **Properties Enforced** | | |
 | Security properties provided | [Describe] | **Full software isolation of loads, stores, and jumps** — a sandbox cannot read/write/jump outside its 4 GiB region (the static verifier guarantees the reserved-register + guard invariants); plus a "no-loads" mode (stores+jumps only) that permits read-only cross-sandbox access for compartmentalization; Spectre-breakout safety by construction. |
 | **Resilience** | | |
-| Compartment crashes isolated | ✅ / ❌ | **✅** — out-of-bounds accesses hit unmapped guard regions and **trap** (page fault → signal to the runtime); the runtime mediates and schedules sandboxes. Not framed as an explicit recovery experiment. |
+| Compartment crashes isolated | ✅ / ❌ | **✅ (author-confirmed)** — compartment crashes are isolated. Invalid accesses within a compartment are not guaranteed to cause a crash (the sandbox may keep executing), but every access is guaranteed to be contained within the sandbox. Out-of-bounds accesses that hit unmapped guard regions trap to the runtime. |
 | **Interface Safety** | | |
 | Provides means to facilitate boundary checking/validation | ✅ / ❌ / Partial | **✅** — the runtime mediates all runtime calls and **checks arguments** (e.g., can disallow access to certain directories); the static verifier rejects any binary using unsafe instructions/addressing. |
 | **Trust & Threats** | | |
@@ -45,7 +45,7 @@
 |----------------|------------|-------------------|
 | General runtime overhead | SPEC 2017 (platform/native) | **SPEC 2017**: geomean **6.4% (Apple M1) / 7.3% (GCP T2A)** for full isolation (O2); **~1%** for the stores+jumps-only ("no loads") mode; worst single benchmark 17% (leela). vs Wasm: roughly **half** Wasm's overhead (WAMR 18–22%, Wasm2c-pinned 16%, Wasmtime 47–67%). |
 | Domain switch cost | lmbench lat_ctx (platform/native) | **Cross-sandbox `yield` = 17–18 ns (~50 cycles)**; syscall 22–26 ns (**6× faster than Linux's** 129–160 ns); no hardware mode/pagetable switch. |
-| Domain creation cost | lmbench lat_proc exec (platform/native) | Verification ~**34 MB/s** (each SPEC binary verifies < 0.3 s); **`fork` supported in a single address space** (CoW via Linux `memfd`). No explicit end-to-end creation-latency number. |
+| Domain creation cost | lmbench lat_proc exec (platform/native) | Author-provided: sandbox creation is **~500 µs by default**, optimizable to **~1–15 µs** (Deterministic Client paper, Section 7.2.1), varying with the amount of sandbox code/data. The verifier was optimized after the original paper to **~250 MB/s** (rough estimate, machine/architecture-dependent; the paper reported ~34 MB/s). `fork` is supported in a single address space (CoW via Linux `memfd`). |
 | Inter-domain call latency | lmbench lat_pipe (platform/native) | `yield` (microkernel-like IPC) **17–18 ns (~50 cycles)** — potentially faster than optimized microkernel IPC (~400-cycle hardware limit). |
 | Inter-domain throughput | lmbench bw_pipe (platform/native) | `pipe` round-trip **46–48 ns** vs Linux 1504–2494 ns and gVisor 22899 ns. |
 | Memory overhead per domain | MB/domain | **4 GiB virtual address space per sandbox** (+ 48 KiB guard regions), but mostly **unmapped** — physical use = actual usage. Code size: +12.9% text / +8.3% binary. |
@@ -59,7 +59,7 @@
 | **Dimension** | **Metric** | **Value / Notes** |
 |----------------|------------|-------------------|
 | **Deployment Assumptions** | | |
-| What hardware does it need? | Commodity / Specialized | **ARM64 (AArch64) only** — commodity ARM (Apple M1, AWS Graviton); exploits ARM64 addressing modes. **Not x86.** SVE scatter/gather is disallowed by the verifier. |
+| What hardware does it need? | Commodity / Specialized | **Commodity AArch64 and x86-64.** The original paper was AArch64-only (exploiting ARM64 addressing modes; Apple M1, AWS Graviton); x86-64 support was added in follow-up work (see the x86-64 LLVM RFC and the Segue / Deterministic Client papers). Upstream LLVM currently supports AArch64, with x86-64 in progress. On AArch64, SVE scatter/gather is disallowed by the verifier. |
 | What OS/kernel does it need? | Stock / Module / Modified / Custom | **Stock Linux** — standard page protections + signals; no kernel modifications (Asahi Linux / standard Linux in eval). |
 | What privileges does it need? | User / Root / Kernel access | **User** — userspace sandboxing; the runtime is a normal process. (Kernel address space optionally gives 128Ki sandboxes). |
 | Other deployment requirements | [e.g. custom libc, modified toolchain] | The LFI runtime + static verifier + **SFI-instrumented runtime libraries** (musl-libc, compiler-rt, libc++, libc++abi, libunwind). |
@@ -73,10 +73,10 @@
 | Required expertise level | Low / Medium / High / Expert | **N/A** — self-report/operational dimension; not assessable by an external evaluator from the paper. |
 | Build effort | [build changes / time / deps] | Compile → LFI transform (~1,500 LOC tool) → assemble; link with SFI-instrumented runtime libraries. |
 | **Developer Experience** | | |
-| Debugging support | Standard / Custom / Limited | **N/A** — self-report/operational dimension; not assessable by an external evaluator from the paper. |
+| Debugging support | Standard / Custom / Limited | **Standard (author-confirmed)** — GDB and LLDB work on code executing in a sandbox; existing debugging tools work normally as long as the sandboxed program's debug info is registered after the sandbox is loaded. |
 | Failure modes visibility | [crashes/logs/error codes/silent] | Out-of-bounds access → **trap** (unmapped guard region → page-fault → runtime signal); the verifier **rejects** unsafe binaries at load. |
 | **Availability** | | |
-| License | Open source / Closed / Commercial / Other | **Open source — MPL 2.0** (paper Artifact A.2: "Code licenses: MPL 2.0") `github.com/zyedidia/lfi` (+ `lfi-artifact`). Paper licensed CC-BY 4.0. |
+| License | Open source / Closed / Commercial / Other | **Open source — MIT** (current). The original paper artifact was MPL 2.0, but the code has since been relicensed to MIT across the repositories in the `lfi-project` GitHub organization. The rewriter code that is now part of LLVM is under the LLVM license (Apache 2.0 with LLVM exceptions). Paper licensed CC-BY 4.0. |
 | Primary usage | Production / Research / Internal / Experimental / Other | **Research** — prototype oriented toward cloud/serverless adoption. |
 
 ---
@@ -86,7 +86,7 @@
 | **Dimension** | **Metric** | **Value / Notes** |
 |----------------|------------|-------------------|
 | **Cross-Framework Composability** | | |
-| Integrates with other compartmentalization mechanisms | ✅ / ❌ | **✅** — composes with virtualization/containers (can run inside a VM) and can use ARM extensions (CSV2_2 for Spectre); future hardware-SFI support discussed. |
+| Integrates with other compartmentalization mechanisms | ✅ / ❌ | **✅ (author-confirmed, mechanism-dependent)** — in general composes with Intel MPK, Intel CET, Arm PAC, LLVM SafeStack, and virtualization/containers (can run inside a VM); can use Arm CSV2_2 for Spectre. |
 | Can coexist with other compartmentalization systems | ✅ / ❌ | **✅** — tens of thousands of sandboxes + the runtime coexist in one process; runs as a normal Linux process. |
 | Can stack effectively | ✅ / ❌ | **✅** — up to ~64Ki sandboxes compose in one address space. |
 | **Inter-Compartment Interactions** | | |
@@ -103,7 +103,7 @@
 | Process model | fork/exec / Custom / N/A | **✅ Unix-like process model** — the runtime implements `open`/`read`/`write`/`fork`/`wait`/`pipe`/`mmap` within one Linux process; `fork` works in a single address space. |
 | POSIX compatibility | Full / Partial / Limited | **Partial (good)** — the runtime provides a small Unix-like OS; musl libc (some glibc-specific programs unsupported). |
 | **Composition Limitations** | | |
-| Known limitations when composed | [Describe] | ARM64 only; **4 GiB max per sandbox** (SPECspeed >4 GiB excluded); SVE scatter/gather disallowed; glibc-specific programs unsupported (musl). |
+| Known limitations when composed | [Describe] | **4 GiB max per sandbox** (SPECspeed >4 GiB excluded); on AArch64 SVE scatter/gather disallowed; glibc-specific programs unsupported (musl). (The paper was AArch64-only; x86-64 is now supported via follow-up work.) |
 | Security caveats when layered | [Describe] | Full Spectre poisoning mitigation needs ARM CSV2_2 (Cortex-X2+, not universal); the verifier's external disassembler deps are in the TCB; the "no-loads" mode deliberately allows cross-sandbox reads. |
 
 ---
@@ -125,16 +125,16 @@
 
 ## Summary
 
-> **What it is:** The first software fault isolation (SFI) scheme for **ARM64** — it sandboxes untrusted code by rewriting loads, stores, and jumps with cheap guard instructions (exploiting ARM64 addressing modes for ~0–1 cycle guards), supports **tens of thousands of 4 GiB sandboxes in one address space** with fast (~50-cycle) context switches, and uses a small **static machine-code verifier** to keep the TCB tiny (no trusted compiler).
+> **What it is:** A software fault isolation (SFI) scheme, the first for **AArch64** and since extended to **x86-64** — it sandboxes untrusted code by rewriting loads, stores, and jumps with cheap guard instructions (on AArch64, exploiting addressing modes for ~0–1 cycle guards), supports **tens of thousands of 4 GiB sandboxes in one address space** with fast (~50-cycle) context switches, and uses a small **static machine-code verifier** to keep the TCB tiny (no trusted compiler). Part of the rewriter is now upstream in LLVM.
 >
-> **Who it's for:** Cloud/serverless/edge platforms running many short-lived untrusted programs that need both low CPU overhead *and* fast context switches, on ARM64.
+> **Who it's for:** Cloud/serverless/edge platforms running many short-lived untrusted programs that need both low CPU overhead *and* fast context switches, on AArch64 or x86-64.
 >
 > **What it protects:** Each sandbox from the others — full software isolation of loads/stores/jumps within a 4 GiB region (or stores+jumps only in the lighter compartmentalization mode).
 >
-> **What it costs (effort/money/performance):** 6.4–7.3% runtime overhead on SPEC 2017 (~1% for stores+jumps only), ~13% code size; recompilation through the LFI toolchain; ARM64 only.
+> **What it costs (effort/money/performance):** 6.4–7.3% runtime overhead on SPEC 2017 (~1% for stores+jumps only), ~13% code size; recompilation through the LFI toolchain.
 >
-> **What it needs (hardware/OS/expertise):** Commodity ARM64, stock Linux, the LFI runtime + verifier + SFI-instrumented musl toolchain; ARM CSV2_2 for full Spectre mitigation.
+> **What it needs (hardware/OS/expertise):** Commodity AArch64 or x86-64, stock Linux, the LFI runtime + verifier + SFI-instrumented musl toolchain; Arm CSV2_2 for full Spectre mitigation on AArch64.
 >
-> **Key tradeoffs:** Near-virtualization CPU overhead *with* microkernel-beating context-switch speed and a tiny verifier-based TCB, plus broad software support (exceptions/SIMD/setjmp) and Spectre-breakout safety by construction — but it is ARM64-only, capped at 4 GiB per sandbox, requires recompilation, and full Spectre-poisoning mitigation needs a recent ARM extension.
+> **Key tradeoffs:** Near-virtualization CPU overhead *with* microkernel-beating context-switch speed and a tiny verifier-based TCB, plus broad software support (exceptions/SIMD/setjmp) and Spectre-breakout safety by construction — but it is capped at 4 GiB per sandbox, requires recompilation, and full Spectre-poisoning mitigation needs a recent ARM extension.
 >
-> **Additional Notes:** A strong, well-rounded SFI data point — directly comparable to **HFI** (proposed hardware) and **Occlum's MMDSFI** (x86/MPX), but pure-software on commodity ARM64. The "verifier keeps the compiler out of the TCB" idea mirrors Occlum; the toolchain-independence is a notable maintainability advantage.
+> **Additional Notes:** A strong, well-rounded SFI data point — directly comparable to **HFI** (proposed hardware) and **Occlum's MMDSFI** (x86/MPX). The "verifier keeps the compiler out of the TCB" idea mirrors Occlum; the toolchain-independence is a notable maintainability advantage. Post-publication, LFI added x86-64 support, relicensed to MIT (the `lfi-project` GitHub organization), and landed part of the rewriter upstream in LLVM (see llvm.org/docs/LFI.html and the AArch64/x86-64 LLVM RFCs); follow-up work includes the Segue and Deterministic Client papers.


### PR DESCRIPTION
An evaluation matrix is a structured rubric we fill in for each compartmentalization system, scoring it across a fixed set of dimensions (security, performance, usability, composability, and so on) so the systems can be compared side by side on the same terms. Each cell is either a cited fact from the paper, a value from the system's repo, an inferred judgment, or marked N/A or Unknown.

Review is welcome from anyone, and especially from the paper's authors. If you know the system well, please check the cells I inferred or characterized qualitatively and let me know where I got something wrong. The "Where I need review" section below points at the specific cells I am least sure about.

[View rendered matrix](https://github.com/ORCA-LF/evaluation-criteria-matrix/blob/389b1a22b906f1a3243de24e61d943ad37a09775/evaluations/lfi.md)

## What it is
LFI (Lightweight Fault Isolation) is a software fault isolation (SFI) scheme presented by Z. Yedidia in "Lightweight Fault Isolation: Practical, Efficient, and Secure Software Sandboxing" at ASPLOS 2024 (DOI 10.1145/3620665.3640408). It addresses the problem of running many untrusted programs in one address space with low CPU overhead and fast context switches, targeting cloud, serverless, and edge settings, on commodity hardware rather than specialized hardware. The paper targeted AArch64; per the author, LFI now also supports x86-64 (follow-up work), part of the rewriter is upstream in LLVM, and the matrix below reflects those updates.

- Compartment is a sandbox: an aligned 4 GiB region in a shared address space, holding a process-like untrusted program, with tens of thousands of such sandboxes coexisting in one address space.
- Mechanism: pure software fault isolation with no hardware isolation primitive. Guard instructions are added to loads, stores, and jumps (exploiting ARM64 addressing modes for roughly 0 to 1 cycle guards), a static machine-code verifier confirms the invariants on the final binary, and standard page protections (W xor X) are set once at init.
- Trust model: the TCB is the static verifier (core is 300 LOC of Rust, plus its disassembler, ELF reader, and instruction-definition dependencies), the runtime, and the OS and CPU. The compiler and the LFI assembly transformer (about 1,500 LOC) are not trusted, because the verifier checks the final machine code. This keeps LLVM's roughly 2M LOC out of the TCB.

## Key takeaways
- Runtime overhead on SPEC CPU 2017 is a geomean of 6.4% on Apple M1 and 7.3% on GCP T2A for full isolation (O2), and about 1% for the lighter stores-and-jumps-only ("no loads") mode, with the worst single benchmark at 17% (leela). This is roughly half the overhead of the Wasm engines compared against (WAMR 18 to 22%, Wasm2c-pinned 16%, Wasmtime 47 to 67%).
- Context switches are cheap: cross-sandbox yield is 17 to 18 ns (about 50 cycles) with no hardware mode or page-table switch, and a runtime-mediated syscall is 22 to 26 ns, about 6x faster than Linux's 129 to 160 ns. Pipe round-trip is 46 to 48 ns versus 1504 to 2494 ns on Linux and 22899 ns on gVisor.
- Each sandbox reserves 4 GiB of virtual address space (plus 48 KiB guard regions) but most of it stays unmapped, so physical use tracks actual usage. Code grows about 12.9% (text) and 8.3% (binary). The domain count is bounded by virtual address space: about 64Ki sandboxes in 48-bit userspace, up to 128Ki using kernel address space.
- Spectre sandbox-breakout is mitigated by construction because LFI uses no fine-grained CFI and all jumps are data-flow-guarded, but full cross-sandbox or host poisoning mitigation needs ARM's CSV2_2 extension (Cortex-X2 and later, not universal). It requires recompilation through the LFI toolchain with an SFI-instrumented musl toolchain.

## Resolved by the author

The LFI author (Zach Yedidia) reviewed this and confirmed several cells:
- Compartment crashes isolated: yes. Invalid accesses within a compartment are not guaranteed to crash (the sandbox may keep executing) but are guaranteed to be contained within the sandbox.
- Domain creation cost: ~500 µs by default, optimizable to ~1–15 µs (Deterministic Client paper, Section 7.2.1); the verifier was optimized to ~250 MB/s after the original paper.
- Debugging support: GDB and LLDB work on sandboxed code once its debug info is registered after loading.
- Integrates with other mechanisms: generally yes, including Intel MPK, Intel CET, Arm PAC, LLVM SafeStack, and virtualization.

## Where I still need review
- Runtime Efficiency › Performance scales with domain count (Inferred): per-sandbox runtime state is constant, and I inferred memory is O(n) in virtual space.
- Usability self-report dimensions (required expertise, monitoring/orchestration, config complexity, maintenance burden) are marked N/A; the author noted these are not straightforward for him to evaluate either.

License: MIT (current). The original paper artifact was MPL 2.0; the code has since been relicensed to MIT across the lfi-project GitHub organization, and the rewriter now in LLVM is under the LLVM license (Apache 2.0 with LLVM exceptions). Paper text licensed CC-BY 4.0.
