### PR TITLE
Add WALI compartmentalization evaluation

### DIFF
--- a/evaluations/wali.md
+++ b/evaluations/wali.md
@@ -1,0 +1,140 @@
+# Compartmentalization Evaluation Matrix — WALI
+
+**Version:** v0.1
+**System:** WALI (The WebAssembly Linux Interface)
+**Paper:** A. Ramesh, T. Huang, B. L. Titzer, A. Rowe. Stop Hiding The Sharp Knives: The WebAssembly Linux Interface. arXiv:2312.03858v1 (Dec 2023), CMU + Bosch Research.
+
+> Complete this matrix for a single implementation or system.
+> Use ✅ / ❌ for checkboxes, categorical scales, and short text values as indicated.
+
+---
+
+## Security
+
+| **Dimension** | **Metric** | **Value / Notes** |
+|----------------|------------|-------------------|
+| **Isolation Model** | | |
+| Primary use case | Untrusted component isolation / Secret protection / Fault isolation / Other | **Untrusted component isolation** — run untrusted, polyglot Wasm modules in an in-process memory sandbox at near-native speed (cloud/edge + cyber-physical/embedded), with WALI giving them a full Linux syscall interface. |
+| Subject selection | Code-centric / Data-centric / Hybrid | **Code-centric** — the isolated subject is a Wasm module. |
+| Code-centric granularity | Function / Library / Thread / Process / VM / N/A | **Library / module** — a WebAssembly module/instance, in-process. |
+| Data-centric granularity | Object / Region / Page / Allocation / File / N/A | **N/A** (Wasm linear-memory sandbox; "multiple isolated memories" can give disjoint privileged memory). |
+| **Isolation Approach** | | |
+| Hardware primitive(s) | MPK/PKU / MTE / CHERI / TEEs / Other / None | **None** — WebAssembly is software sandboxing (no HW primitive). |
+| Software technique(s) | SFI / Boundary wrappers/marshalling / Memory-safe language / Language runtime / Other / None | **Language runtime / bytecode VM (WebAssembly)** — memory-safe linear-memory sandbox + **control-flow integrity (CFI)**; WALI itself is **boundary wrappers/marshalling** (a thin syscall translation layer between Wasm and Linux). |
+| Isolation abstraction | Process / Thread / Intra-Address Space Domain / VM / Container / Other | **Intra-Address Space Domain** — in-process Wasm sandbox; multiple WALI processes can be co-located in one native process. |
+| Requires runtime software support | ✅ / ❌ (describe) | **✅** — a WebAssembly engine implementing WALI; reference implementation on **WAMR** (WebAssembly Micro Runtime, interpreter + AOT). |
+| **Properties Enforced** | | |
+| Security properties provided | [Describe] | **Wasm sandbox:** modules cannot access external state unless explicitly imported; **CFI** rules out remote-code-injection/ROP from memory-safety bugs. **WALI's own model is *relaxed*:** it exposes the raw Linux syscall surface (no capability confinement like WASI) — trading OS-level confinement for compatibility/portability; syscall-level security is **delegated to complementary mechanisms (seccomp/Draco)**. "Multiple isolated memories" allow a privileged memory disjoint from app memory. |
+| **Resilience** | | |
+| Compartment crashes isolated | ✅ / ❌ | **✅** — a Wasm trap/memory-safety violation is contained within the module's sandbox; not framed as a crash-recovery mechanism. |
+| **Interface Safety** | | |
+| Provides means to facilitate boundary checking/validation | ✅ / ❌ / Partial | **Partial** — the Wasm boundary enforces memory-safety + CFI and translates/validates syscall pointer arguments across the Wasm↔native boundary; but WALI deliberately does **not** confine *which* syscalls a module may invoke (relaxed model) — that is left to seccomp/Draco. |
+| **Trust & Threats** | | |
+| TCB includes | Compiler / OS / Firmware / CPU / Other (list) | **The Wasm engine** (WAMR) + the **Linux kernel** (full userspace syscall surface is exposed) + **CPU/hardware**. WALI **shrinks the engine's TCB** by pushing higher-level API implementations (e.g. WASI) *out* of the TCB — implemented as sandboxed layers over WALI. |
+| TCB approximate size | Small / Medium / Large / Very Large or [LOC] | **WALI itself is ≈2,000 lines of C** (with <100 lines of arch-specific code per platform). For contrast, a WASI implementation built *over* WALI (libuvwasi) is **>6,000 lines in the engine** — WALI keeps that OS-feature surface thin and pushes higher-level APIs out of the engine TCB. The engine (WAMR) + Linux kernel remain the TCB; **no total engine/TCB LOC** reported → **Unknown** for the absolute size. |
+| Side-channel resistance | Cache / Timing / Speculative / Other / None (mitigations) | **None** — not addressed (Wasm does not prevent µarch side channels; not discussed). |
+| **Validation** | | |
+| Formal validation available | Yes (specify) / No | **No** for WALI itself — though it builds on WebAssembly, which has a machine-checked formal semantics (cited); WALI is not formally verified. |
+| Experimental validation available | Yes (specify) / No | **Yes** — reference implementation on WAMR; evaluated across many real applications (e.g. bash, Lua, others) with intrinsic (syscall) and extrinsic (virtualization) overhead measurements. |
+
+---
+
+## Runtime Efficiency
+
+| **Dimension** | **Metric** | **Value / Notes** |
+|----------------|------------|-------------------|
+| General runtime overhead | SPEC 2017 (platform/native) | **No SPEC.** Near-native for AOT-compiled Wasm; **≈2× slower than Docker on average**; the signal-handling polling scheme adds **<10%** over WALI-without-polling. _(The paper notes Lua runs up to **60% slower than native in Docker** — cited as a reason such allocation-heavy apps are good WALI candidates, **not** a WALI overhead figure.)_ WALI's own overhead is dominated by the underlying syscall + engine. |
+| Domain switch cost | lmbench lat_ctx (platform/native) | **Unknown (no lmbench).** A Wasm→host syscall is the native syscall cost plus argument translation; no isolated context-switch figure. |
+| Domain creation cost | lmbench lat_proc exec (platform/native) | **Unknown** — Wasm instance/process creation latency not reported as a figure (WALI models Linux process/thread creation via `clone`). |
+| Inter-domain call latency | lmbench lat_pipe (platform/native) | **Unknown / N/A** — modules interact via Wasm imports/host functions and standard Linux IPC (which WALI exposes); no isolated figure. |
+| Inter-domain throughput | lmbench bw_pipe (platform/native) | **Unknown** — no inter-module bandwidth figure. |
+| Memory overhead per domain | MB/domain | **Unknown** — Wasm linear memory per module; no MB/module overhead figure reported. |
+| Domain count bounded by | Limiting factor; approx. domain count | multiple Wasm modules / WALI processes can be co-located in one native process; bounded by host memory/process limits. No specific count. |
+| Performance scales with domain count | Big O | **Unknown** — not characterized. |
+
+---
+
+## Usability / Adoptability
+
+| **Dimension** | **Metric** | **Value / Notes** |
+|----------------|------------|-------------------|
+| **Deployment Assumptions** | | |
+| What hardware does it need? | Commodity / Specialized | **Commodity** — portable across host ISAs (x86, ARM, etc.) via the Wasm engine; targets embedded/cyber-physical + cloud/edge. |
+| What OS/kernel does it need? | Stock / Module / Modified / Custom | **Stock Linux** — WALI *is* the Linux userspace syscall interface for Wasm (non-Linux hosts — Windows/BSD/Darwin/QNX — are future work). |
+| What privileges does it need? | User / Root / Kernel access | **User** — runs as a normal process hosting the Wasm engine. |
+| Other deployment requirements | [e.g. custom libc, modified toolchain] | A WALI-supporting Wasm engine (WAMR reference) + a Wasm-enabled toolchain. |
+| **Software Compatibility** | | |
+| What application changes are needed? | None / Annotations / API changes / Refactoring / Rewrite | **Recompile only** — "porting applications only requires recompilation with a Wasm-enabled toolchain … comparatively trivial effort," because standard libraries/ABIs already operate over the Linux syscall API. |
+| Can it run existing binaries? | Yes / Recompile only / Source changes needed | **Recompile to Wasm** (not unmodified native binaries). |
+| What languages does it support? | C/C++ / Rust / Go / Managed / Any / Other | **Polyglot** — C/C++, Rust, Java, C#, … (anything compiling to Wasm); Lua/Python via runtimes. |
+| Other compatibility notes | [Describe] | Faithfully models the Linux syscall interface — supports `mmap`, `fork`/`exec`, async I/O, signals, threads (which **WASI lacks**), giving strong Linux/POSIX compatibility. |
+| **Developer Effort** | | |
+| Porting effort for typical app | [person-days] | **Low ("trivial" recompile)**; no person-days figure → otherwise **Unknown** for a precise number. |
+| Required expertise level | Low / Medium / High / Expert | **N/A** — self-report/operational dimension; not assessable by an external evaluator from the paper. |
+| Build effort | [build changes / time / deps] | Recompile with a Wasm toolchain; link against the WALI-enabled engine. |
+| **Developer Experience** | | |
+| Debugging support | Standard / Custom / Limited | **N/A** — self-report/operational dimension; not assessable by an external evaluator from the paper. |
+| Failure modes visibility | [crashes/logs/error codes/silent] | Wasm traps on memory-safety/CFI violations; syscall errors surface as normal Linux errnos through WALI. |
+| **Availability** | | |
+| License | Open source / Closed / Commercial / Other | **Open source — MIT** (`github.com/arjunr2/WALI`; GitHub SPDX = MIT). Paper: "WALI is fully open source and available at github.com/arjunr2/WALI". |
+| Primary usage | Production / Research / Internal / Experimental / Other | **Research** prototype (reference implementation on WAMR), targeting cyber-physical/embedded + cloud/edge deployment. |
+
+---
+
+## Composability
+
+| **Dimension** | **Metric** | **Value / Notes** |
+|----------------|------------|-------------------|
+| **Cross-Framework Composability** | | |
+| Integrates with other compartmentalization mechanisms | ✅ / ❌ | **✅** — explicitly **complementary to WASI** (WASI and other capability APIs are implemented *as sandboxed layers over* WALI) and to **seccomp/Draco** for syscall-layer security. |
+| Can coexist with other compartmentalization systems | ✅ / ❌ | **✅** — runs as a normal Linux process; multiple WALI/Wasm modules co-locate in one native process or run as separate processes. |
+| Can stack effectively | ✅ / ❌ | **✅** — higher-level APIs stack as sandboxed layers over WALI; multiple modules compose. |
+| **Inter-Compartment Interactions** | | |
+| How compartments invoke each other | Function calls / Message passing / RPC / Syscalls / Other | **Syscalls** (Wasm module → Linux via WALI imports) + **host-function calls**; cross-module via Linux IPC primitives that WALI exposes. |
+| How compartments share data | Shared memory / Message passing / Serialization / Other | Via the Linux syscall interface (shared memory, pipes, sockets) that WALI exposes; Wasm linear memories are otherwise disjoint. |
+| Interaction semantics | Synchronous / Asynchronous / Both | **Both** — WALI models synchronous syscalls plus async I/O and signals. |
+| Interaction security/validation | [Describe] | Wasm boundary enforces memory-safety + CFI + pointer-argument translation; syscall *authorization* is **not** confined by WALI (relaxed model) — delegated to seccomp/Draco. |
+| **Decomposition Model** | | |
+| Decomposition boundary | Library / Service / Thread / Process / VM / Other | **Wasm module/instance**. |
+| Who defines boundaries | Programmer / Compiler / Runtime / Kernel / Hardware | **Compiler/Runtime** — the Wasm toolchain produces sandboxed modules; the engine enforces the sandbox. |
+| Boundaries flexible at runtime | ✅ / ❌ | **✅** — Wasm modules/instances are created/loaded dynamically by the engine. |
+| **System Integration** | | |
+| Threading model | Standard threads / Custom threading / Other | **Standard** — WALI models Linux threads via the `clone` syscall (Wasm threads → native threads). |
+| Process model | fork/exec / Custom / N/A | **fork/exec supported** — WALI faithfully models Linux processes (`fork`/`exec`/`clone`), unlike WASI. |
+| POSIX compatibility | Full / Partial / Limited | **Strong (Linux-syscall-faithful)** — supports `mmap`, `fork`/`exec`, async I/O, signals, threads; effectively Linux-ABI compatible (Linux-only). |
+| **Composition Limitations** | | |
+| Known limitations when composed | [Describe] | Linux-only (non-Linux hosts future work); performance depends on the underlying Wasm engine; relaxed security model needs complementary confinement. |
+| Security caveats when layered | [Describe] | Exposing the **full raw syscall surface widens the OS attack surface** vs WASI capabilities — *must* be paired with seccomp/Draco or a capability layer for OS-level confinement. |
+
+---
+
+## System Design & Operations
+
+| **Dimension** | **Metric** | **Value / Notes** |
+|----------------|------------|-------------------|
+| **Target Environment** | | |
+| Primary deployment target | Embedded / IoT / Cloud / Server / Desktop / Other | **Embedded / cyber-physical** (IoT, automotive, industrial) **+ Cloud/edge** — long-lived, polyglot, legacy-software-friendly deployments. |
+| Deployment scale | Single device / Cluster / Large scale | **Single device → Large scale** (edge devices to cloud fleets); not framed as a scale dimension. |
+| **Integration** | | |
+| Monitoring/orchestration support | Good / Limited / None | **N/A** — self-report/operational dimension; not assessable by an external evaluator from the paper. |
+| **Operations** | | |
+| Initial configuration complexity | Low / Medium / High | **N/A** — self-report/operational dimension; not assessable by an external evaluator from the paper. |
+| Ongoing maintenance burden | Low / Medium / High | **N/A** — self-report/operational dimension; not assessable by an external evaluator from the paper. |
+
+---
+
+## Summary
+
+> **What it is:** A thin **WebAssembly system interface** that exposes Linux's userspace syscall API directly to sandboxed Wasm modules — letting entire Linux software stacks be recompiled to Wasm "as-is" and run portably across host ISAs, while inheriting WebAssembly's in-process memory sandbox and CFI.
+>
+> **Who it's for:** Developers virtualizing untrusted, polyglot, often-legacy software (cyber-physical/embedded, cloud/edge) who need broad Linux compatibility (mmap, fork/exec, signals, threads) that WASI doesn't provide.
+>
+> **What it protects:** Via WebAssembly — module memory isolation + control-flow integrity (no remote code injection). WALI itself does **not** confine the syscall surface (relaxed vs WASI capabilities); OS-level confinement is delegated to complementary seccomp/Draco.
+>
+> **What it costs (effort/money/performance):** Recompile-only porting ("trivial"); runtime near-native (AOT), ≈2× vs Docker on average and <10% for the signal-polling scheme; the security cost is a **wider OS attack surface** that must be re-confined externally.
+>
+> **What it needs (hardware/OS/expertise):** A WALI-enabled Wasm engine (WAMR reference) on stock Linux; a Wasm-enabled toolchain. Commodity hardware, any host ISA.
+>
+> **Key tradeoffs:** Maximizes Linux compatibility and portability and shrinks the engine TCB (API impls move out of the TCB, layered over WALI) — but deliberately trades WASI's capability confinement for raw syscall access, so the isolation is only as strong as WebAssembly's sandbox *plus* whatever OS-level confinement (seccomp) is layered on.
+>
+> **Additional Notes:** Like K23 and HFI, WALI is a **primitive**, not a full compartmentalization system — the isolation is WebAssembly's; WALI is the interface (and a security-relevant *de-confinement* tradeoff). Reference engine: WAMR.


### PR DESCRIPTION
An evaluation matrix is a structured rubric we fill in for each compartmentalization system, scoring it across a fixed set of dimensions (security, performance, usability, composability, and so on) so the systems can be compared side by side on the same terms. Each cell is either a cited fact from the paper, a value from the system's repo, an inferred judgment, or marked N/A or Unknown.

Review is welcome from anyone, and especially from the paper's authors. If you know the system well, please check the cells I inferred or characterized qualitatively and let me know where I got something wrong. The "Where I need review" section below points at the specific cells I am least sure about.

[View rendered matrix](https://github.com/ORCA-LF/evaluation-criteria-matrix/blob/b659a8dd0f3fc8da23a47aa9756c2ab2e115dc2a/evaluations/wali.md)

## What it is
WALI (The WebAssembly Linux Interface) is a thin system interface that exposes Linux's userspace syscall API directly to sandboxed WebAssembly modules, letting whole Linux software stacks be recompiled to Wasm and run portably across host ISAs. It comes from Ramesh, Huang, Titzer, and Rowe (CMU and Bosch Research), "Stop Hiding The Sharp Knives: The WebAssembly Linux Interface," arXiv:2312.03858v1 (Dec 2023). It is a primitive rather than a standalone isolation mechanism: the isolation is WebAssembly's in-process sandbox, and WALI is the syscall layer beneath it. Its deliberate design choice is to expose the raw syscall surface ("sharp knives") instead of WASI's capability model, which broadens the OS attack surface and relies on complementary OS confinement.

- Compartment is a WebAssembly module/instance, isolated in-process by the Wasm sandbox (linear-memory bounds plus control-flow integrity).
- Mechanism: no hardware primitive; software sandboxing via the WebAssembly bytecode VM (memory-safe linear memory plus CFI), with WALI acting as a boundary/marshalling layer that translates syscalls between Wasm and Linux. Requires a WALI-supporting Wasm engine (the reference implementation runs on WAMR).
- Trust model: the TCB includes the Wasm engine (WAMR), the Linux kernel (the full userspace syscall surface is exposed), and the CPU/hardware. WALI shrinks the engine's TCB by pushing higher-level APIs such as WASI out of the engine and implementing them as sandboxed layers over WALI. Wasm modules are untrusted; WALI itself does not confine which syscalls a module may invoke, leaving that to seccomp/Draco.

## Key takeaways
- WALI itself is about 2,000 lines of C, with under 100 lines of arch-specific code per platform. A WASI implementation built over WALI (libuvwasi) is over 6,000 lines in the engine, illustrating the design goal of keeping the OS-feature surface thin and out of the engine TCB. No total engine/TCB LOC is reported.
- Runtime cost is near-native for AOT-compiled Wasm, roughly 2x slower than Docker on average, and the signal-handling polling scheme adds under 10% over WALI without polling. No SPEC 2017 or lmbench figures are reported.
- The security tradeoff is explicit: exposing the full raw syscall surface widens the OS attack surface compared to WASI capabilities, so WALI must be paired with seccomp/Draco or a capability layer for OS-level confinement. The Wasm boundary still enforces memory safety, CFI, and pointer-argument translation.
- Porting is recompile-only ("trivial"), supports any language that compiles to Wasm (C/C++, Rust, Java, C#, and Lua/Python via runtimes), and provides strong Linux/POSIX compatibility (mmap, fork/exec, async I/O, signals, threads) that WASI lacks. It targets stock Linux only; non-Linux hosts are future work.

## Where I need review
- Compartment crashes isolated (Security, Resilience): marked _Inferred:_ true. A Wasm trap or memory-safety violation is contained in the module sandbox, but the paper does not frame this as a crash-recovery mechanism.
- Domain count bounded by (Runtime Efficiency): marked _Inferred:_. Multiple modules/WALI processes co-locate in one native process, bounded by host memory/process limits; no specific count is reported.
- Can coexist with other compartmentalization systems (Composability): marked _Inferred:_ true, reasoning that WALI runs as a normal Linux process and modules can co-locate or run separately.
- Boundaries flexible at runtime (Composability): marked _Inferred:_ true, since the engine loads/creates Wasm instances dynamically.
- Deployment scale (System Design): marked _Inferred:_ "single device to large scale"; the paper does not frame this as a scale dimension.
- TCB approximate size (Security): Unknown for the absolute engine/TCB size; only WALI's own ~2,000 LOC and the libuvwasi >6,000 LOC contrast are reported.
- Runtime Efficiency figures: domain switch cost, domain creation cost, inter-domain call latency, inter-domain throughput, memory overhead per domain, and performance scaling (Big O) are all Unknown, with no lmbench-style measurements in the paper.
- Porting effort for typical app (Usability): described as low/trivial, but no person-day figure is given, so the precise number is Unknown.
- Required expertise level, Debugging support, Monitoring/orchestration support, Initial configuration complexity, Ongoing maintenance burden: all N/A as self-report/operational dimensions an external evaluator cannot assess from the paper (policy 2026-06-09).
- Structural placement: WALI is treated as a primitive (like K23 and HFI) rather than a full compartmentalization system, since the isolation is WebAssembly's. This matrix placement should be confirmed with the ORCA team.

License: MIT (repo, github.com/arjunr2/WALI, GitHub SPDX = MIT; paper §1 states it is fully open source).
