### PR TITLE
Add gVisor compartmentalization evaluation

### DIFF
--- a/evaluations/gvisor.md
+++ b/evaluations/gvisor.md
@@ -1,0 +1,140 @@
+# Compartmentalization Evaluation Matrix — gVisor
+
+**Version:** v0.1
+**System:** gVisor (Google's userspace application kernel / container sandbox; compartment = a sandboxed container, guarded by the Sentry)
+**Paper:** None — gVisor has no single flagship paper. Evaluated from official docs (gvisor.dev architecture/security guides), the gVisor security-basics blog, and the GitHub repo.
+
+> Complete this matrix for a single implementation or system.
+> Use ✅ / ❌ for checkboxes, categorical scales, and short text values as indicated.
+
+---
+
+## Security
+
+| **Dimension** | **Metric** | **Value / Notes** |
+|----------------|------------|-------------------|
+| **Isolation Model** | | |
+| Primary use case | Untrusted component isolation / Secret protection / Fault isolation / Other | **Untrusted component isolation** — sandbox untrusted container workloads so they cannot exploit the host kernel; limits the host kernel surface accessible to the application. |
+| Subject selection | Code-centric / Data-centric / Hybrid | **Code-centric** — the isolated subject is a whole container/workload. |
+| Code-centric granularity | Function / Library / Thread / Process / VM / N/A | **Container** (process group) — one sandbox per container; ≈Process/Container granularity. |
+| Data-centric granularity | Object / Region / Page / Allocation / File / N/A | **N/A** — isolation is whole-sandbox, not data-object granular. |
+| **Isolation Approach** | | |
+| Hardware primitive(s) | MPK/PKU / MTE / CHERI / TEEs / Other / None | **Mostly None / optional virtualization** — default interception is software (Systrap/seccomp-bpf or ptrace); the optional **KVM platform** uses hardware virtualization to let the Sentry act as guest-kernel + VMM. |
+| Software technique(s) | SFI / Boundary wrappers/marshalling / Memory-safe language / Language runtime / Other / None | **Other — userspace kernel re-implementation in a memory-safe language (Go)** + **syscall interception** (Systrap/ptrace/KVM platforms) + **seccomp-bpf** confinement of the Sentry/Gofer. |
+| Isolation abstraction | Process / Thread / Intra-Address Space Domain / VM / Container / Other | **Container** sandbox, implemented as host processes (Sentry, Gofer) with restricted privileges; similar to virtual machines… two separate kernels but without a full guest OS. |
+| Requires runtime software support | ✅ / ❌ (describe) | **✅** — the **Sentry** (guest kernel in userspace, ≈Linux syscall ABI in Go), the **Gofer** (filesystem proxy), and the **`runsc`** OCI runtime; a syscall-interception platform (Systrap default / ptrace / KVM). |
+| **Properties Enforced** | | |
+| Security properties provided | [Describe] | **No syscall is passed through to the host** — every supported call has an independent Sentry implementation; the Sentry cannot open new files / create sockets / etc. on the host (the Gofer mediates files). Two confinement layers: the workload is trapped by the Sentry, and the Sentry itself is confined by seccomp-bpf to a small host-syscall set. Defense-in-depth engineering rules: only universal functionality implemented; unsafe code quarantined to `unsafe.go`; no CGo (pure-Go binary). |
+| **Resilience** | | |
+| Compartment crashes isolated | ✅ / ❌ | **✅** — each container runs in its own Sentry/sandbox; a crash is confined to that sandbox (one sandbox per container). (Not stated as a recovery experiment.) |
+| **Interface Safety** | | |
+| Provides means to facilitate boundary checking/validation | ✅ / ❌ / Partial | **✅** — the Sentry is a complete mediation point: it parses/validates every syscall and its arguments in userspace before deciding whether any (heavily restricted) host action occurs; the Gofer validates all filesystem access. |
+| **Trust & Threats** | | |
+| TCB includes | Compiler / OS / Firmware / CPU / Other (list) | **The Sentry + Gofer (Go), the `runsc` runtime, the host Linux kernel (small reduced surface still reachable), CPU/firmware.** The host kernel remains in the TCB but its exposed surface is deliberately minimized vs a normal container. |
+| TCB approximate size | Small / Medium / Large / Very Large or [LOC] | **Medium** — the Sentry is a substantial from-scratch kernel re-implementation (exposes ≈**240 syscalls** to the workload, of which ≈**100** can reach the host) but written in memory-safe Go; the Sentry's *own* host footprint is restricted to ≈**70 syscalls** via seccomp, the Gofer even fewer. No authoritative LOC figure for the TCB. |
+| Side-channel resistance | Cache / Timing / Speculative / Other / None (mitigations) | **None (explicitly out of scope)** — gVisor does not defend against hardware side channels; side-channel/network attacks are outside its primary defense scope. |
+| **Validation** | | |
+| Formal validation available | Yes (specify) / No | **No** — no formal proofs; relies on Go memory safety, the structural no passthrough design, and extensive syscall-compatibility testing. |
+| Experimental validation available | Yes (specify) / No | **Yes (engineering, not a paper)** — published performance guide (syscall latency, memory density, network/IO benchmarks vs runc) and a large open syscall test suite; widely deployed in Google Cloud (GKE Sandbox / Cloud Run). |
+
+---
+
+## Runtime Efficiency
+
+| **Dimension** | **Metric** | **Value / Notes** |
+|----------------|------------|-------------------|
+| General runtime overhead | SPEC 2017 (platform/native) | **No SPEC.** Docs frame overhead as **structural** (syscall interception, Sentry memory) vs **implementation** (network stack, VFS). Rule of thumb: small operations impose a large overhead… the more work an application does the smaller the impact of structural costs. CPU-bound code with few syscalls runs near-native. |
+| Domain switch cost | lmbench lat_ctx (platform/native) | **No lat_ctx figure.** Every intercepted syscall pays a userspace round-trip into the Sentry; magnitude depends heavily on platform (ptrace slowest; Systrap/KVM faster). Not quantified in lmbench terms. |
+| Domain creation cost | lmbench lat_proc exec (platform/native) | **No precise figure.** Container startup carries overhead, but most of the time overhead… is associated [with] Docker itself; using `runsc do` / the OCI runtime directly reduces it. No ms value given. |
+| Inter-domain call latency | lmbench lat_pipe (platform/native) | **Not reported as lat_pipe.** In-sandbox IPC is Sentry-implemented; cross-sandbox is ordinary networking. No isolated latency figure. |
+| Inter-domain throughput | lmbench bw_pipe (platform/native) | **Not bw_pipe.** Network throughput (iperf) underperforms runc, especially for minimal work per request synthetic benchmarks — mostly bound by implementation costs of the userspace netstack. |
+| Memory overhead per domain | MB/domain | **A small, mostly fixed amount of memory overhead per sandbox** (Sentry process), plus per-instance cost shown in Node/Ruby density benchmarks vs runc. No single authoritative MB/sandbox number. |
+| Domain count bounded by | Limiting factor; approx. domain count | **host memory + per-sandbox Sentry overhead** (one Sentry+Gofer process set per container). No explicit max count. |
+| Performance scales with domain count | Big O | memory **O(n)** in sandbox count (fixed-ish Sentry overhead each); no asymptotic statement in docs. |
+
+---
+
+## Usability / Adoptability
+
+| **Dimension** | **Metric** | **Value / Notes** |
+|----------------|------------|-------------------|
+| **Deployment Assumptions** | | |
+| What hardware does it need? | Commodity / Specialized | **Commodity** — builds/runs on x86-64 and ARM64; software platforms (Systrap/ptrace) need no virtualization; the optional KVM platform uses commodity VT-x. |
+| What OS/kernel does it need? | Stock / Module / Modified / Custom | **Stock Linux** — runs on an unmodified host kernel as userspace processes (no kernel module); Systrap/ptrace use standard seccomp/ptrace, KVM uses the stock KVM subsystem. |
+| What privileges does it need? | User / Root / Kernel access | container-runtime privileges to set up namespaces/seccomp (typical OCI runtime install); the sandbox itself runs **unprivileged** with dropped capabilities. |
+| Other deployment requirements | [e.g. custom libc, modified toolchain] | Install `runsc` as an OCI/Docker runtime or enable GKE Sandbox; no guest image or custom libc — the app runs against the Sentry's Linux ABI. |
+| **Software Compatibility** | | |
+| What application changes are needed? | None / Annotations / API changes / Refactoring / Rewrite | **None** — runs unmodified container images against the Sentry's reimplemented Linux ABI. |
+| Can it run existing binaries? | Yes / Recompile only / Source changes needed | **Yes** — unmodified Linux binaries, subject to compatibility gaps (the Sentry implements a large but not 100% subset of Linux; some syscalls/`/proc`/ioctls/raw sockets are unimplemented by design). |
+| What languages does it support? | C/C++ / Rust / Go / Managed / Any / Other | **Any** — language-agnostic; anything that runs as a Linux container, within ABI-coverage limits. (gVisor *itself* is written in Go.) |
+| Other compatibility notes | [Describe] | Specialized/less-universal APIs are deliberately omitted (raw sockets, many ioctls); apps needing those may not run. The netstack and VFS are reimplemented, so behavior can differ subtly from the host kernel. |
+| **Developer Effort** | | |
+| Porting effort for typical app | [person-days] | **~Zero for the workload** — drop-in `runsc` runtime, no app changes (compatibility permitting). |
+| Required expertise level | Low / Medium / High / Expert | **N/A** — self-report/operational dimension; not assessable by an external evaluator. |
+| Build effort | [build changes / time / deps] | No app rebuild; operators install the `runsc` binary and register it as a runtime. |
+| **Developer Experience** | | |
+| Debugging support | Standard / Custom / Limited | **N/A** — self-report/operational dimension; not assessable by an external evaluator. _(Docs do mention `runsc` debug logging/strace-like tooling, but no explicit rating.)_ |
+| Failure modes visibility | [crashes/logs/error codes/silent] | Unimplemented syscalls return errors (e.g. `ENOSYS`) rather than passing to the host; `runsc` provides debug logs of intercepted syscalls. |
+| **Availability** | | |
+| License | Open source / Closed / Commercial / Other | **Open source — Apache 2.0**. |
+| Primary usage | Production / Research / Internal / Experimental / Other | **Production** — Google's container sandbox, used in GKE Sandbox, Cloud Run, and App Engine; actively maintained open-source project. |
+
+---
+
+## Composability
+
+| **Dimension** | **Metric** | **Value / Notes** |
+|----------------|------------|-------------------|
+| **Cross-Framework Composability** | | |
+| Integrates with other compartmentalization mechanisms | ✅ / ❌ | **✅** — implements the OCI runtime interface (`runsc`), so it composes with Docker, containerd, and Kubernetes/GKE as a drop-in secure runtime; can layer on Linux namespaces/cgroups/seccomp. |
+| Can coexist with other compartmentalization systems | ✅ / ❌ | **✅** — runs side-by-side with `runc` and other runtimes on the same host; per-container choice of runtime. |
+| Can stack effectively | ✅ / ❌ | **✅** — many independent sandboxes coexist; can run inside a VM (Systrap platform is explicitly well-suited to run inside a virtual machine). |
+| **Inter-Compartment Interactions** | | |
+| How compartments invoke each other | Function calls / Message passing / RPC / Syscalls / Other | **Networking / IPC** — separate sandboxes communicate like separate containers (network sockets); within a sandbox the Sentry provides the syscall/IPC surface. The Sentry↔Gofer link is a dedicated socket. |
+| How compartments share data | Shared memory / Message passing / Serialization / Other | **Message passing / networking** between sandboxes; filesystem sharing is mediated by the **Gofer** over a socket; the sandbox starts in an empty mount namespace. |
+| Interaction semantics | Synchronous / Asynchronous / Both | **Both** — synchronous syscall emulation + async I/O/networking; not explicitly characterized. |
+| Interaction security/validation | [Describe] | All workload→host interaction is mediated and re-implemented by the Sentry; all filesystem access is mediated by the Gofer; both confined by seccomp. |
+| **Decomposition Model** | | |
+| Decomposition boundary | Library / Service / Thread / Process / VM / Other | **Container** (per-sandbox). |
+| Who defines boundaries | Programmer / Compiler / Runtime / Kernel / Hardware | **Runtime** — the container runtime/orchestrator decides what runs in a gVisor sandbox; the developer ships an ordinary container image. |
+| Boundaries flexible at runtime | ✅ / ❌ | **✅** — sandboxes are created/destroyed per container on demand by the orchestrator. |
+| **System Integration** | | |
+| Threading model | Standard threads / Custom threading / Other | **Standard** (from the app's view) — the Sentry implements Linux threading; underlying scheduling differs by platform. |
+| Process model | fork/exec / Custom / N/A | **Standard fork/exec** semantics, re-implemented inside the Sentry. |
+| POSIX compatibility | Full / Partial / Limited | **Partial** — a large but incomplete subset of the Linux/POSIX ABI; deliberately omits some syscalls/ioctls/raw-sockets and exposes a reduced `/proc`. |
+| **Composition Limitations** | | |
+| Known limitations when composed | [Describe] | ABI-coverage gaps (some syscalls/ioctls unimplemented); reimplemented netstack/VFS impose throughput/latency costs; system-call-heavy and IO/network-heavy workloads see the largest overhead. |
+| Security caveats when layered | [Describe] | Hardware side channels explicitly **out of scope**; the host kernel surface is reduced but not eliminated (≈100 of the Sentry's syscalls can still reach the host) — a kernel bug in that residual surface remains reachable. |
+
+---
+
+## System Design & Operations
+
+| **Dimension** | **Metric** | **Value / Notes** |
+|----------------|------------|-------------------|
+| **Target Environment** | | |
+| Primary deployment target | Embedded / IoT / Cloud / Server / Desktop / Other | **Cloud / Server** — sandboxing untrusted containers in multi-tenant cloud (GKE Sandbox, Cloud Run, App Engine). |
+| Deployment scale | Single device / Cluster / Large scale | **Large scale** — deployed across Google Cloud's container platforms. |
+| **Integration** | | |
+| Monitoring/orchestration support | Good / Limited / None | **Good** — OCI/`runsc` runtime integrates with Kubernetes/Docker/containerd monitoring & orchestration; runtime-level metrics/debug logs available. _(Stated via OCI integration, so reported rather than N/A.)_ |
+| **Operations** | | |
+| Initial configuration complexity | Low / Medium / High | **N/A** — self-report/operational dimension; not assessable by an external evaluator. |
+| Ongoing maintenance burden | Low / Medium / High | **N/A** — self-report/operational dimension; not assessable by an external evaluator. |
+
+---
+
+## Summary
+
+> **What it is:** A userspace application kernel for containers: gVisor's **Sentry** re-implements the Linux syscall ABI from scratch in memory-safe Go and intercepts every syscall an untrusted container makes, so the workload talks to the Sentry instead of the host kernel. A separate **Gofer** mediates filesystem access, and both are confined to the host by seccomp-bpf. It ships as the `runsc` OCI runtime.
+>
+> **Who it's for:** Cloud/container operators who want a stronger isolation boundary than plain Linux containers (runc) for untrusted workloads, without paying for a full guest kernel/VM per container.
+>
+> **What it protects:** The host kernel (and other tenants) from untrusted container code — by ensuring no syscall is passed straight through, drastically shrinking the reachable host-kernel attack surface (the Sentry itself is limited to ~70 host syscalls; ~100 of the ~240 it exposes can reach the host).
+>
+> **What it costs (effort/money/performance):** Near-zero porting effort (drop-in runtime) but real runtime overhead — every syscall is intercepted, and the reimplemented netstack/VFS make syscall-heavy and IO/network-heavy workloads noticeably slower than runc; compute-bound workloads run near-native. A small, mostly fixed memory overhead per sandbox.
+>
+> **What it needs (hardware/OS/expertise):** Commodity x86-64/ARM64, a stock Linux host (no kernel module), and the `runsc` runtime — no application changes, within ABI-compatibility limits.
+>
+> **Key tradeoffs:** Stronger isolation than runc with full container-image compatibility and no special hardware, at the price of per-syscall interception overhead, partial Linux ABI coverage, and **no defense against hardware side channels**. It sits between plain containers and full VMs (Firecracker): a userspace kernel rather than a hardware-virtualized guest.
+>
+> **Additional Notes:** This is a **baseline / container-isolation** reference entry (a secure container runtime), not an intra-process compartmentalization technique. No flagship paper — evaluated entirely from gvisor.dev docs, the security-basics blog, and the repo; several efficiency cells (lat_ctx, MB/sandbox, TCB-LOC) are genuinely unreported as hard numbers. Contrast with Firecracker (the VM-based baseline) — both were requested as the non-intra-process reference points for the matrix.


### PR DESCRIPTION
An evaluation matrix is a structured rubric we fill in for each compartmentalization system, scoring it across a fixed set of dimensions (security, performance, usability, composability, and so on) so the systems can be compared side by side on the same terms. Each cell is either a cited fact from the paper, a value from the system's repo, an inferred judgment, or marked N/A or Unknown.

Review is welcome from anyone, and especially from the system's authors and maintainers. If you know the system well, please check the cells I inferred or characterized qualitatively and let me know where I got something wrong. The "Where I need review" section below points at the specific cells I am least sure about.

[View rendered matrix](https://github.com/ORCA-LF/evaluation-criteria-matrix/blob/69924c18bb812ec9ead13bfa8577886414acef5f/evaluations/gvisor.md)

## What it is
gVisor is Google's userspace application kernel for containers. Because there is no single flagship paper, this entry was built from the official gvisor.dev documentation (architecture and security guides, performance guide), the gVisor security-basics blog, and the GitHub repo. The isolation problem it addresses is running untrusted container workloads in multi-tenant environments without giving them direct access to the host kernel: instead of passing syscalls through to the host, gVisor intercepts them and services them in a separate userspace kernel, shrinking the reachable host-kernel attack surface.

- Compartment is a sandboxed container: one sandbox per container, with the untrusted workload running against the Sentry rather than the host kernel.
- Mechanism: a from-scratch re-implementation of the Linux syscall ABI in memory-safe Go (the Sentry), plus syscall interception (the default Systrap platform, or ptrace, or the optional KVM platform that uses hardware virtualization), a Gofer process that mediates filesystem access, and seccomp-bpf confinement of the Sentry and Gofer. The default interception path uses no special hardware primitive.
- Trust model: the TCB includes the Sentry and Gofer (Go), the runsc OCI runtime, the host Linux kernel (a reduced but non-zero surface remains reachable), and the CPU/firmware. The untrusted container workload is outside the TCB; no syscall is passed straight through to the host.

## Key takeaways
- The Sentry exposes roughly 240 syscalls to the workload, of which about 100 can reach the host, while the Sentry's own host footprint is restricted to about 70 syscalls via seccomp (the Gofer even fewer). This is the concrete sense in which the host-kernel attack surface is reduced versus a plain runc container.
- Overhead is structural rather than incidental: every intercepted syscall pays a userspace round-trip into the Sentry, and the reimplemented netstack and VFS make syscall-heavy and IO/network-heavy workloads noticeably slower than runc, while compute-bound workloads run near-native. The docs frame this qualitatively and do not publish SPEC, lmbench, or a single MB-per-sandbox figure.
- Porting effort is near zero: gVisor runs unmodified Linux container images as a drop-in runsc OCI runtime under Docker, containerd, and Kubernetes, subject to partial Linux ABI coverage (some syscalls, ioctls, raw sockets, and parts of /proc are deliberately unimplemented).
- Hardware side channels are explicitly out of scope, and there is no formal validation; assurance rests on Go memory safety, the structural no-passthrough design, and an extensive syscall-compatibility test suite. It is in production across GKE Sandbox, Cloud Run, and App Engine.

## Where I need review
This entry is doc-based rather than paper-based, so several efficiency cells are qualitative or platform-dependent where a paper would normally give hard numbers.

- TCB approximate size (Security): marked Medium with syscall counts but no authoritative LOC figure for the Sentry/Gofer codebase.
- Domain switch cost, domain creation cost, inter-domain call latency, inter-domain throughput, and memory overhead per domain (Runtime Efficiency): no lmbench or MB-per-sandbox numbers in the docs; described qualitatively and as platform-dependent.
- Compartment crashes isolated (Security): inferred from one-sandbox-per-container design, not stated as a recovery experiment.
- Privileges required (Usability): inferred as container-runtime privileges to set up namespaces/seccomp, with the sandbox itself running unprivileged.
- Domain count bounded by and performance scales with domain count (Runtime Efficiency): inferred as host memory plus per-sandbox Sentry overhead, memory O(n) in sandbox count; no asymptotic statement in the docs.
- Can stack effectively (Composability): inferred yes from many coexisting sandboxes and the Systrap platform being suited to run inside a VM.
- Interaction semantics (Composability): inferred Both (synchronous syscall emulation plus async I/O); not explicitly characterized.
- Required expertise level and Debugging support (Usability), and Initial configuration complexity and Ongoing maintenance burden (System Design and Operations): N/A under the self-report policy, since an external evaluator cannot assess these operational dimensions.

License: Apache 2.0 (gVisor GitHub repo, github.com/google/gvisor).
