### PR TITLE
Add K23 compartmentalization evaluation

### DIFF
--- a/evaluations/k23.md
+++ b/evaluations/k23.md
@@ -31,7 +31,7 @@
 | Provides means to facilitate boundary checking/validation | ✅ / ❌ / Partial | **✅ (K23's core contribution)** — reliable, exhaustive, tamper-resistant interposition (complete mediation) of the syscall interface with **full expressiveness** (deep argument/pointer inspection). This is the boundary-mediation primitive syscall sandboxes depend on. |
 | **Trust & Threats** | | |
 | TCB includes | Compiler / OS / Firmware / CPU / Other (list) | **K23's runtime** (`libLogger`/`ptracer`/`libK23`), the **offline logs** (integrity-critical — marked immutable), the **OS kernel** (ptrace/SUD), and the **orthogonal isolation mechanism (PKU)** used for self-protection. |
-| TCB approximate size | Small / Medium / Large / Very Large or [LOC] | **Unknown — Not quantified in LOC.** Designed to be plug-and-play and to **avoid OS/hardware modifications** (a smaller TCB than intrusive approaches), but no LOC figure given. |
+| TCB approximate size | Small / Medium / Large / Very Large or [LOC] | **Small — ~4K LoC (author-provided).** The paper gives no LOC figure; the author reports the codebase is about 4K lines of code. Consistent with the plug-and-play design that **avoids OS/hardware modifications**. |
 | Side-channel resistance | Cache / Timing / Speculative / Other / None (mitigations) | **N/A** — not an isolation mechanism. |
 | **Validation** | | |
 | Formal validation available | Yes (specify) / No | **No.** |
@@ -70,7 +70,7 @@
 | Other compatibility notes | [Describe] | **x86-64 only**; an offline phase with representative inputs is needed for best performance, with an SUD fallback catching anything missed. |
 | **Developer Effort** | | |
 | Porting effort for typical app | [person-days] | **~None** (plug-and-play); the effort is running the offline phase + writing the interposer logic for a given use case. |
-| Required expertise level | Low / Medium / High / Expert | **N/A** — self-report/operational dimension; not assessable by an external evaluator from the paper. |
+| Required expertise level | Low / Medium / High / Expert | **Low (author-provided).** The author reports 3–4 students built projects over K23 without prior knowledge; a simple `syscall_handler` function is populated by K23 users to define the interposition logic. |
 | Build effort | [build changes / time / deps] | None for the app; run the offline profiling phase (seconds–minutes). |
 | **Developer Experience** | | |
 | Debugging support | Standard / Custom / Limited | K23 is itself a **debugging/tracing enabler**, and it fixes prior interposers' debugging pitfalls (e.g., P4a's NULL-code-pointer debugging nightmares). |
@@ -87,7 +87,7 @@
 |----------------|------------|-------------------|
 | **Cross-Framework Composability** | | |
 | Integrates with other compartmentalization mechanisms | ✅ / ❌ | **✅** — explicitly **designed to compose** with an orthogonal isolation mechanism (PKU) for self-protection, and to serve as a building block for sandboxing / N-variant / security tools. |
-| Can coexist with other compartmentalization systems | ✅ / ❌ | **✅** — in-process, transparent, per-process; composes with PKU-based isolation. |
+| Can coexist with other compartmentalization systems | ✅ / ❌ | **✅ (author-confirmed)** — the author confirms it should be straightforward for K23 to work together with compartmentalization schemes, e.g., PKU-based. In-process, transparent, and per-process. |
 | Can stack effectively | ✅ / ❌ | **✅** — re-attaches `ptracer` and re-runs the online phase across `execve`/`fork`, so spawned processes are re-interposed. |
 | **Inter-Compartment Interactions** | | |
 | How compartments invoke each other | Function calls / Message passing / RPC / Syscalls / Other | **N/A** — no compartments. (Internally, intercepted syscalls are redirected via rewritten `call *%rax` or the SUD signal path). |
@@ -118,8 +118,8 @@
 | **Integration** | | |
 | Monitoring/orchestration support | Good / Limited / None | **N/A** — K23 is itself a tracing/observability *enabler*, not a managed system. |
 | **Operations** | | |
-| Initial configuration complexity | Low / Medium / High | **N/A** — self-report/operational dimension; not assessable by an external evaluator from the paper. |
-| Ongoing maintenance burden | Low / Medium / High | **N/A** — self-report/operational dimension; not assessable by an external evaluator from the paper. |
+| Initial configuration complexity | Low / Medium / High | **Low (author-provided).** The author reports operations, maintenance, etc. are similarly low-effort (cf. students building over K23 with no prior knowledge). |
+| Ongoing maintenance burden | Low / Medium / High | **Low (author-provided).** Per the author, operations and maintenance are low-effort. |
 
 ---
 
@@ -137,4 +137,4 @@
 >
 > **Key tradeoffs:** First interposer to combine **exhaustiveness, tamper-resistance, and high efficiency** without OS/hardware changes — but it is x86-64-only, needs an offline profiling phase, and is an **enabling mechanism rather than a compartmentalization system** (no isolation of its own; relies on PKU for self-protection).
 >
-> **Additional Notes:** For the ORCA matrix, K23 should be treated as a **building block** for syscall-based sandboxing, not as a compartmentalization system. Its one strong matrix fit is *Interface Safety / complete mediation*; most isolation, decomposition, and per-domain efficiency rows are **N/A by category**. Recommend confirming with the ORCA team whether such enabling mechanisms belong in the matrix or in a separate primitives list (cf. the similar Junction/HFI/OSv edge-case notes).
+> **Additional Notes:** For the ORCA matrix, K23 should be treated as a **building block** for syscall-based sandboxing, not as a compartmentalization system. **The author concurs**: he would not personally classify K23 as a compartmentalization technique, but rather as a primitive that can be used to enforce isolation, e.g., building sandboxes. Its one strong matrix fit is *Interface Safety / complete mediation*; most isolation, decomposition, and per-domain efficiency rows are **N/A by category**. Recommend confirming with the ORCA team whether such enabling mechanisms belong in the matrix or in a separate primitives list (cf. the similar Junction/HFI/OSv edge-case notes).

--- a/evaluations/k23.md
+++ b/evaluations/k23.md
@@ -1,0 +1,140 @@
+# Compartmentalization Evaluation Matrix — K23
+
+**Version:** v0.1
+**System:** K23 (general-purpose x86-64 system-call interposition mechanism)
+**Paper:** J. M. Gómez Moreno, V. Moutafis, A. Dionysiou, F. Kuipers, G. Smaragdakis, B. Coppens, A. Voulimeneas. Clair Obscur: The Light and Shadow of System Call Interposition – From Pitfalls to Solutions with K23. ACM Middleware 2025. DOI 10.1145/3721462.3770772.
+
+> Complete this matrix for a single implementation or system.
+> Use ✅ / ❌ for checkboxes, categorical scales, and short text values as indicated.
+
+---
+
+## Security
+
+| **Dimension** | **Metric** | **Value / Notes** |
+|----------------|------------|-------------------|
+| **Isolation Model** | | |
+| Primary use case | Untrusted component isolation / Secret protection / Fault isolation / Other | **Other — general-purpose system-call interposition** (tracing, debugging, security/sandboxing, OS-compat layers, N-variant execution, sanitization). It *enables* syscall-based sandboxing but is not itself an isolation mechanism. |
+| Subject selection | Code-centric / Data-centric / Hybrid | **N/A** — K23 intercepts a whole process's syscall interface; it does not isolate a sub-process subject. |
+| Code-centric granularity | Function / Library / Thread / Process / VM / N/A | **Process** (whole-process, thread-aware syscall interception) — not a sub-process isolation unit. |
+| Data-centric granularity | Object / Region / Page / Allocation / File / N/A | **N/A.** |
+| **Isolation Approach** | | |
+| Hardware primitive(s) | MPK/PKU / MTE / CHERI / TEEs / Other / None | **None for interposition itself** (pure software). It **uses PKU** to mark its trampoline page execute-only and **recommends PKU** (orthogonal) to protect its own internal state — not to isolate the application. |
+| Software technique(s) | SFI / Boundary wrappers/marshalling / Memory-safe language / Language runtime / Other / None | **Other** — hybrid **binary rewriting** (zpoline-style) + **ptrace** + **SUD (Syscall User Dispatch)**, split across an offline profiling phase and an online phase. |
+| Isolation abstraction | Process / Thread / Intra-Address Space Domain / VM / Container / Other | **N/A** — K23 is in-process (single, shared address space); it provides no isolation domain. |
+| Requires runtime software support | ✅ / ❌ (describe) | **✅** — three components: `libLogger` (offline, SUD), `ptracer` (online startup, ptrace, cross-process), `libK23` (online, SUD + binary rewriting); built on Linux ptrace/SUD. |
+| **Properties Enforced** | | |
+| Security properties provided | [Describe] | **Exhaustive, tamper-resistant complete mediation of the syscall interface** — intercepts *all* syscalls, including those issued before/during library loading, via vdso, and from dynamically-generated code; resists bypass (P1), overlook (P2), instruction-misidentification/corruption (P3), NULL-access pitfalls (P4), and runtime-rewriting races (P5). **It provides NO memory isolation** — that is delegated to an orthogonal mechanism. |
+| **Resilience** | | |
+| Compartment crashes isolated | ✅ / ❌ | **N/A** — no isolation domains (in-process). A NULL-execution check aborts the process on an invalid interposer entry. |
+| **Interface Safety** | | |
+| Provides means to facilitate boundary checking/validation | ✅ / ❌ / Partial | **✅ (K23's core contribution)** — reliable, exhaustive, tamper-resistant interposition (complete mediation) of the syscall interface with **full expressiveness** (deep argument/pointer inspection). This is the boundary-mediation primitive syscall sandboxes depend on. |
+| **Trust & Threats** | | |
+| TCB includes | Compiler / OS / Firmware / CPU / Other (list) | **K23's runtime** (`libLogger`/`ptracer`/`libK23`), the **offline logs** (integrity-critical — marked immutable), the **OS kernel** (ptrace/SUD), and the **orthogonal isolation mechanism (PKU)** used for self-protection. |
+| TCB approximate size | Small / Medium / Large / Very Large or [LOC] | **Unknown — Not quantified in LOC.** Designed to be plug-and-play and to **avoid OS/hardware modifications** (a smaller TCB than intrusive approaches), but no LOC figure given. |
+| Side-channel resistance | Cache / Timing / Speculative / Other / None (mitigations) | **N/A** — not an isolation mechanism. |
+| **Validation** | | |
+| Formal validation available | Yes (specify) / No | **No.** |
+| Experimental validation available | Yes (specify) / No | **Yes** — pitfall PoCs (P1–P5), pitfall comparison vs zpoline/lazypoline (Table 3), micro + macrobenchmarks (Table 5) on coreutils + nginx/lighttpd/sqlite/redis. Open-source. Host: 12-core Intel Xeon w5-3425, 64 GB, Ubuntu 22.04.5 / kernel 6.8. |
+
+---
+
+## Runtime Efficiency
+
+| **Dimension** | **Metric** | **Value / Notes** |
+|----------------|------------|-------------------|
+| General runtime overhead | SPEC 2017 (platform/native) | **No SPEC.** Microbenchmark (100M no-op syscalls): **K23-default 1.28×**, K23-ultra 1.39×, K23-ultra+ 1.39× vs native; compared to zpoline 1.13×, lazypoline 1.38×, **SUD 15.3×**, and ptrace (prohibitive). K23 matches state-of-the-art interposers. |
+| Domain switch cost | lmbench lat_ctx (platform/native) | **N/A** — no isolation domains. The relevant metric is per-syscall interposition overhead (~1.28×, above). |
+| Domain creation cost | lmbench lat_proc exec (platform/native) | **N/A.** (Offline profiling phase completes in seconds–minutes; `ptracer` is used only at startup, then K23 switches to the fast `libK23`). |
+| Inter-domain call latency | lmbench lat_pipe (platform/native) | **N/A** — no compartments. |
+| Inter-domain throughput | lmbench bw_pipe (platform/native) | **N/A.** |
+| Memory overhead per domain | MB/domain | **N/A** — no per-domain state. K23 keeps only a small **hash set of logged syscall-instruction sites** (the paper's summary range is **7–44 in experiments**; per-category: 7–13 for coreutils, 20–92 for larger server/datacenter apps) — negligible, vs zpoline's full-address-space bitmap. |
+| Domain count bounded by | Limiting factor; approx. domain count | **N/A.** |
+| Performance scales with domain count | Big O | **N/A** — per-process `libK23`; lower memory than zpoline (no whole-address-space bitmap). |
+
+---
+
+## Usability / Adoptability
+
+| **Dimension** | **Metric** | **Value / Notes** |
+|----------------|------------|-------------------|
+| **Deployment Assumptions** | | |
+| What hardware does it need? | Commodity / Specialized | **Commodity x86-64** (PKU used for the trampoline page / self-protection). |
+| What OS/kernel does it need? | Stock / Module / Modified / Custom | **Stock Linux** — uses standard **ptrace + SUD**; no kernel or hardware modifications (plug-and-play). (SUD requires Linux ≥ 5.11). |
+| What privileges does it need? | User / Root / Kernel access | **User** — operates within the user's own process tree via ptrace/SUD; no kernel patches. |
+| Other deployment requirements | [e.g. custom libc, modified toolchain] | An offline profiling run with representative inputs; `LD_PRELOAD` injection (force-injected via `ptracer`); an immutable offline-log directory. |
+| **Software Compatibility** | | |
+| What application changes are needed? | None / Annotations / API changes / Refactoring / Rewrite | **None** — fully transparent, no app changes, no recompilation; just an offline profiling phase. |
+| Can it run existing binaries? | Yes / Recompile only / Source changes needed | **Yes** — unmodified x86-64 binaries. |
+| What languages does it support? | C/C++ / Rust / Go / Managed / Any / Other | **Any** — operates on x86-64 binaries regardless of source language. |
+| Other compatibility notes | [Describe] | **x86-64 only**; an offline phase with representative inputs is needed for best performance, with an SUD fallback catching anything missed. |
+| **Developer Effort** | | |
+| Porting effort for typical app | [person-days] | **~None** (plug-and-play); the effort is running the offline phase + writing the interposer logic for a given use case. |
+| Required expertise level | Low / Medium / High / Expert | **N/A** — self-report/operational dimension; not assessable by an external evaluator from the paper. |
+| Build effort | [build changes / time / deps] | None for the app; run the offline profiling phase (seconds–minutes). |
+| **Developer Experience** | | |
+| Debugging support | Standard / Custom / Limited | K23 is itself a **debugging/tracing enabler**, and it fixes prior interposers' debugging pitfalls (e.g., P4a's NULL-code-pointer debugging nightmares). |
+| Failure modes visibility | [crashes/logs/error codes/silent] | Invalid interposer entry → **abort** (NULL-execution check); detected attempts to disable SUD → **abort** (addresses P1b). |
+| **Availability** | | |
+| License | Open source / Closed / Commercial / Other | **Open source — MIT** (`gitlab.com/tudelft-ssl/k23`, GitLab API license = MIT). Paper licensed CC-BY 4.0. |
+| Primary usage | Production / Research / Internal / Experimental / Other | **Research** — prototype, explicitly aimed at general-purpose community adoption. |
+
+---
+
+## Composability
+
+| **Dimension** | **Metric** | **Value / Notes** |
+|----------------|------------|-------------------|
+| **Cross-Framework Composability** | | |
+| Integrates with other compartmentalization mechanisms | ✅ / ❌ | **✅** — explicitly **designed to compose** with an orthogonal isolation mechanism (PKU) for self-protection, and to serve as a building block for sandboxing / N-variant / security tools. |
+| Can coexist with other compartmentalization systems | ✅ / ❌ | **✅** — in-process, transparent, per-process; composes with PKU-based isolation. |
+| Can stack effectively | ✅ / ❌ | **✅** — re-attaches `ptracer` and re-runs the online phase across `execve`/`fork`, so spawned processes are re-interposed. |
+| **Inter-Compartment Interactions** | | |
+| How compartments invoke each other | Function calls / Message passing / RPC / Syscalls / Other | **N/A** — no compartments. (Internally, intercepted syscalls are redirected via rewritten `call *%rax` or the SUD signal path). |
+| How compartments share data | Shared memory / Message passing / Serialization / Other | **N/A.** |
+| Interaction semantics | Synchronous / Asynchronous / Both | **N/A.** |
+| Interaction security/validation | [Describe] | The interposition interface itself provides **complete syscall mediation** + full argument/pointer inspection. |
+| **Decomposition Model** | | |
+| Decomposition boundary | Library / Service / Thread / Process / VM / Other | **N/A** — K23 does not decompose the application; it intercepts a whole process's syscalls. |
+| Who defines boundaries | Programmer / Compiler / Runtime / Kernel / Hardware | **N/A.** |
+| Boundaries flexible at runtime | ✅ / ❌ | **N/A.** |
+| **System Integration** | | |
+| Threading model | Standard threads / Custom threading / Other | **Per-thread interposition** (SUD operates per-thread); handles multithreaded/multicore apps — and specifically fixes prior runtime-rewriting race pitfalls (P5) by avoiding on-the-fly rewriting. |
+| Process model | fork/exec / Custom / N/A | **Handles fork/`execve`** — re-attaches and re-interposes spawned processes. |
+| POSIX compatibility | Full / Partial / Limited | **Transparent to POSIX apps** — it *intercepts* the POSIX syscall interface without altering app semantics. |
+| **Composition Limitations** | | |
+| Known limitations when composed | [Describe] | **x86-64 only**; needs an offline profiling phase for performance (SUD fallback otherwise); `ptrace` startup overhead (amortized). |
+| Security caveats when layered | [Describe] | **Relies on an orthogonal isolation mechanism (PKU) to protect its own internal state** — K23 provides no memory isolation; offline-log integrity is critical (logs marked immutable); overall security is only as strong as the interposer logic and the isolation layer built around it. |
+
+---
+
+## System Design & Operations
+
+| **Dimension** | **Metric** | **Value / Notes** |
+|----------------|------------|-------------------|
+| **Target Environment** | | |
+| Primary deployment target | Embedded / IoT / Cloud / Server / Desktop / Other | **Broad** — explicitly from low-end devices to performance-critical, datacenter-scale workloads. |
+| Deployment scale | Single device / Cluster / Large scale | **Any** — single device through datacenter. |
+| **Integration** | | |
+| Monitoring/orchestration support | Good / Limited / None | **N/A** — K23 is itself a tracing/observability *enabler*, not a managed system. |
+| **Operations** | | |
+| Initial configuration complexity | Low / Medium / High | **N/A** — self-report/operational dimension; not assessable by an external evaluator from the paper. |
+| Ongoing maintenance burden | Low / Medium / High | **N/A** — self-report/operational dimension; not assessable by an external evaluator from the paper. |
+
+---
+
+## Summary
+
+> **What it is:** A general-purpose, plug-and-play x86-64 **system-call interposition** mechanism that reliably and *exhaustively* intercepts all of an application's system calls — including those before library load, via vdso, and from dynamically-generated code — **without kernel or hardware modifications**, by combining an offline profiling phase (SUD logging) with an online phase (ptrace at startup + selective zpoline-style binary rewriting + SUD fallback). It fixes five interposition pitfalls in prior interposers (zpoline, lazypoline).
+>
+> **Who it's for:** Builders of sandboxing, tracing/debugging, OS-compatibility, N-variant, and security tools who need reliable, efficient, tamper-resistant **complete mediation of the syscall interface**.
+>
+> **What it protects:** **Nothing by itself** — K23 is an interposition primitive, not an isolation mechanism. It supplies the complete syscall mediation that sandboxes depend on, but delegates its own self-protection (and any actual memory isolation) to an orthogonal mechanism such as Intel PKU.
+>
+> **What it costs (effort/money/performance):** ~1.28× syscall overhead (matches state of the art; far below SUD's 15× or ptrace); an offline profiling phase (seconds–minutes); transparent, no app changes.
+>
+> **What it needs (hardware/OS/expertise):** Stock Linux (ptrace + SUD, kernel ≥ 5.11), commodity x86-64 (PKU for self-protection), and an offline profiling run.
+>
+> **Key tradeoffs:** First interposer to combine **exhaustiveness, tamper-resistance, and high efficiency** without OS/hardware changes — but it is x86-64-only, needs an offline profiling phase, and is an **enabling mechanism rather than a compartmentalization system** (no isolation of its own; relies on PKU for self-protection).
+>
+> **Additional Notes:** For the ORCA matrix, K23 should be treated as a **building block** for syscall-based sandboxing, not as a compartmentalization system. Its one strong matrix fit is *Interface Safety / complete mediation*; most isolation, decomposition, and per-domain efficiency rows are **N/A by category**. Recommend confirming with the ORCA team whether such enabling mechanisms belong in the matrix or in a separate primitives list (cf. the similar Junction/HFI/OSv edge-case notes).


### PR DESCRIPTION
An evaluation matrix is a structured rubric we fill in for each compartmentalization system, scoring it across a fixed set of dimensions (security, performance, usability, composability, and so on) so the systems can be compared side by side on the same terms. Each cell is either a cited fact from the paper, a value from the system's repo, an inferred judgment, or marked N/A or Unknown.

Review is welcome from anyone, and especially from the paper's authors. If you know the system well, please check the cells I inferred or characterized qualitatively and let me know where I got something wrong. The "Where I need review" section below points at the specific cells I am least sure about.

[View rendered matrix](https://github.com/ORCA-LF/evaluation-criteria-matrix/blob/c04fdba5e7e961106ab12672141c1debc01547bd/evaluations/k23.md)

## What it is
K23 is a general-purpose x86-64 system-call interposition mechanism from Gomez Moreno et al., "Clair Obscur: The Light and Shadow of System Call Interposition, From Pitfalls to Solutions with K23," ACM Middleware 2025 (DOI 10.1145/3721462.3770772). It is best understood as an enabling primitive rather than a full compartmentalization system: it provides reliable, exhaustive, tamper-resistant complete mediation of an application's syscall interface, the boundary-mediation building block that syscall-based sandboxes, tracers, debuggers, OS-compatibility layers, and N-variant tools depend on. K23 runs in-process and provides no memory isolation of its own, so most isolation rows in the matrix are N/A by category. Its core contribution is fixing five interposition pitfalls (bypass, overlook, instruction misidentification/corruption, NULL-access, and runtime-rewriting races) found in prior interposers such as zpoline and lazypoline.

- Compartment is not applicable: K23 intercepts a whole process's syscall interface and does not isolate a sub-process subject. The closest unit is the process whose syscalls it mediates.
- Mechanism: hybrid software interposition with no isolation hardware of its own. It combines an offline profiling phase (SUD, Syscall User Dispatch, logging) with an online phase (ptrace at startup plus selective zpoline-style binary rewriting plus SUD fallback). It uses Intel PKU to mark its trampoline page execute-only and recommends PKU as an orthogonal mechanism to protect its own internal state.
- Trust model: the TCB includes K23's runtime (libLogger, ptracer, libK23), the offline logs (integrity-critical, marked immutable), the OS kernel (ptrace and SUD), and the orthogonal isolation mechanism (PKU) used for self-protection. K23 itself provides no memory isolation; any actual isolation is delegated to a layer built around it.

## Key takeaways
- Complete syscall mediation is the one strong matrix fit: K23 intercepts all syscalls, including those issued before or during library loading, via vdso, and from dynamically-generated code, with full argument and pointer inspection, and resists bypass and tampering. Most other isolation, decomposition, and per-domain rows are N/A because K23 is a primitive, not an isolation scheme.
- Performance matches state-of-the-art interposers. On a 100M no-op syscall microbenchmark, K23-default is 1.28x native (K23-ultra and K23-ultra+ are 1.39x), compared with zpoline at 1.13x, lazypoline at 1.38x, raw SUD at 15.3x, and ptrace which is prohibitive. There is no SPEC 2017 result.
- Deployment is plug-and-play on stock Linux: commodity x86-64, standard ptrace plus SUD (kernel 5.11 or later), user privileges only, no kernel or hardware modifications, no application changes, and unmodified binaries of any source language. The cost is an offline profiling run with representative inputs (seconds to minutes), with SUD as a fallback for anything missed.
- Memory footprint is small: K23 keeps only a hash set of logged syscall-instruction sites (7 to 44 across experiments), avoiding zpoline's full-address-space bitmap.

## Where I need review
- Security, TCB size: marked Unknown. The paper describes K23 as plug-and-play and avoiding OS/hardware modifications, implying a smaller TCB than intrusive approaches, but gives no LOC figure.
- Composability, can coexist with other compartmentalization systems: marked _Inferred:_ yes, based on K23 being in-process, transparent, and per-process, and composing with PKU-based isolation. Not stated as such in the paper.
- Usability, required expertise level: N/A as a self-report/operational dimension not assessable by an external paper-based evaluator (policy 2026-06-09).
- Operations, initial configuration complexity: N/A for the same self-report/operational reason.
- Operations, ongoing maintenance burden: N/A for the same self-report/operational reason.
- Category caveat: K23 is a syscall-interposition primitive, not a compartmentalization mechanism, so most isolation, decomposition, and per-domain efficiency rows are N/A by category. Worth confirming with the ORCA team whether such enabling mechanisms belong in the matrix or in a separate primitives list.

License: MIT (repo gitlab.com/tudelft-ssl/k23, GitLab API license field; paper itself licensed CC-BY 4.0).
